### PR TITLE
Add  'game' api override card page

### DIFF
--- a/docs/reference/game.md
+++ b/docs/reference/game.md
@@ -1,0 +1,23 @@
+# @extends
+
+## #specific
+
+```cards
+game.reset()
+game.runtime()
+```
+
+## See also #seealso
+
+[over](/reference/game/over),
+[on update](/reference/game/on-update),
+[on update interval](/reference/game/on-update-interval),
+[ask](/reference/game/ask),
+[ask for string](/reference/game/ask-for-string),
+[splash](/reference/game/splash),
+[set dialog cursor](/reference/game/set-dialog-cursor),
+[set dialog frame](/reference/game/set-dialog-frame),
+[set dialog text color](/reference/game/set-dialog-text-color),
+[show long text](/reference/game/show-long-text),
+[reset](/reference/game/reset),
+[runtime](/reference/game/runtime)

--- a/libs/device/ns.ts
+++ b/libs/device/ns.ts
@@ -5,6 +5,7 @@ namespace game {
      */
     //% blockId=arcade_game_runtime block="time since start (ms)"
     //% group="Gameplay" weight=11
+    //% help=game/runtime
     export function runtime(): number {
         return control.millis();
     }
@@ -15,6 +16,7 @@ namespace game {
      */
     //% blockId=arcade_game_reset block="reset game"
     //% group="Gameplay" weight=10
+    //% help=game/reset
     export function reset() {
         control.reset();
     }


### PR DESCRIPTION
Add a _game.md_ card page override to include target local **reset** and **runtime** functions.