### PR TITLE
Use stlink for hw-debugging also on SAMD51

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -77,13 +77,14 @@
                 "hasHex": true,
                 "openocdScriptAlt": "source [find interface/cmsis-dap.cfg]; set CHIPNAME at91samd51g19; source [find target/at91samdXX.cfg]",
                 "openocdScript": "source [find interface/stlink-v2.cfg]; set CPUTAPID 0x2ba01477; set CHIPNAME at91samd51g19; source [find target/at91samdXX.cfg]",
+                "ramSize": 196608,
                 "vtableShift": 4
             },
             "compileService": {
                 "codalTarget": {
                     "name": "codal-itsybitsy-m4",
                     "url": "https://github.com/lancaster-university/codal-itsybitsy-m4",
-                    "branch": "v0.0.4",
+                    "branch": "v0.0.6",
                     "type": "git"
                 },
                 "codalBinary": "ITSYBITSY_M4",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -75,7 +75,8 @@
         "samd51": {
             "compile": {
                 "hasHex": true,
-                "openocdScript": "source [find interface/cmsis-dap.cfg]; set CHIPNAME at91samd51g19; source [find target/at91samdXX.cfg]",
+                "openocdScriptAlt": "source [find interface/cmsis-dap.cfg]; set CHIPNAME at91samd51g19; source [find target/at91samdXX.cfg]",
+                "openocdScript": "source [find interface/stlink-v2.cfg]; set CPUTAPID 0x2ba01477; set CHIPNAME at91samd51g19; source [find target/at91samdXX.cfg]",
                 "vtableShift": 4
             },
             "compileService": {


### PR DESCRIPTION
I left the other openocd for reference; in future we might want `--stlink`/`--cmsis` options to `pxt gdb` but for now it seems stlink is more reliable, cheaper, and already used in the stm32 target