### PR TITLE
Fixes issue with images namespace when SMT32f401 is selected

### DIFF
--- a/libs/screen---st7735/ns.ts
+++ b/libs/screen---st7735/ns.ts
@@ -1,0 +1,5 @@
+
+//% color="#a5b1c2"
+namespace images {
+
+}

--- a/libs/screen---st7735/targetoverrides.ts
+++ b/libs/screen---st7735/targetoverrides.ts
@@ -1,0 +1,29 @@
+/**
+ * Tagged image literal converter
+ */
+//% shim=@f4 helper=image::ofBuffer blockIdentity="images._spriteImage"
+//% groups=["0.","1#","2T","3t","4N","5n","6G","7g","8","9","aAR","bBP","cCp","dDO","eEY","fFW"]
+function img(lits: any, ...args: any[]): Image { return null }
+
+// set palette before creating screen, so the JS version has the right BPP
+image.setPalette(hex`__palette`)
+let screen = image.create(
+    control.getConfigValue(DAL.CFG_DISPLAY_WIDTH, 160), 
+    control.getConfigValue(DAL.CFG_DISPLAY_HEIGHT, 128))
+
+namespace image {
+    //% shim=pxt::setPalette
+    export function setPalette(buf: Buffer) { }
+}
+
+namespace _screen_internal {
+    //% shim=pxt::updateScreen
+    function updateScreen(img: Image): void { }
+    //% shim=pxt::updateStats
+    function updateStats(msg: string): void { }
+
+    control.__screen.setupUpdate(() => updateScreen(screen))
+    control.EventContext.onStats = function (msg: string) {
+        updateStats(msg);
+    }
+}


### PR DESCRIPTION
This fixes the following issues: 
* Images not decompiling into blocks (as mentioned in Microsoft/pxt-arcade#338)
* Images namespace color not being the same as the arcade's namespace images color

Note: The screen size is still set to be 160x128