### PR TITLE
fix dup in throw a bone and initial values

### DIFF
--- a/docs/concepts/sunday-drive.md
+++ b/docs/concepts/sunday-drive.md
@@ -54,7 +54,7 @@ game.onUpdateInterval(1000, function () {
 . . f f f f f e e f f f f f e . 
 . . . f f f . . . . f f f f . . 
 . . . . . . . . . . . . . . . . 
-`, 0, 0, SpriteKind.Player)
+`, 0, 100, SpriteKind.Player)
 })
 ```
 
@@ -86,11 +86,43 @@ game.onUpdateInterval(1000, function () {
 . . f f f f f e e f f f f f e . 
 . . . f f f . . . . f f f f . . 
 . . . . . . . . . . . . . . . . 
-`, 40, 0, SpriteKind.Player)
+`, 40, 100, SpriteKind.Player)
 })
 ```
 
 ## Step 5 @fullscreen
+
+In the ``||sprites:projectile||``, set the ``||sprites:vy||`` to 0, so that the cars drive **only** to the right.
+
+```blocks
+enum SpriteKind {
+    Player,
+    Enemy
+}
+let projectile: Sprite = null;
+game.onUpdateInterval(1000, function () {
+    projectile = sprites.createProjectile(img`
+. . . . . . . . . . . . . . . . 
+. . . . 2 2 2 2 2 2 2 2 . . . . 
+. . . 2 4 2 2 2 2 2 2 c 2 . . . 
+. . 2 c 4 2 2 2 2 2 2 c c 2 . . 
+. 2 c c 4 4 4 4 4 4 2 c c 4 2 d 
+. 2 c 2 e e e e e e e b c 4 2 2 
+. 2 2 e b b e b b b e e b 4 2 2 
+. 2 e b b b e b b b b e 2 2 2 2 
+. e e 2 2 2 e 2 2 2 2 2 e 2 2 2 
+. e e e e e e f e e e f e 2 d d 
+. e e e e e e f e e f e e e 2 d 
+. e e e e e e f f f e e e e e e 
+. e f f f f e e e e f f f e e e 
+. . f f f f f e e f f f f f e . 
+. . . f f f . . . . f f f f . . 
+. . . . . . . . . . . . . . . . 
+`, 40, 0, SpriteKind.Player)
+})
+```
+
+## Step 6 @fullscreen
 
 Find ``||sprites:set mySprite x to 0||`` from ``||sprites:Sprites||``, and drag it after the ``||variables:set projectile to||``. Change ``||variables:mySprite||`` to ``||variables:projectile||``, and change ``||sprites:x||`` to ``||sprites:y||``.
 
@@ -123,7 +155,7 @@ game.onUpdateInterval(1000, function () {
 })
 ```
 
-## Step 6 @fullscreen
+## Step 7 @fullscreen
 
 Find ``||math:pick random 0 to 10||`` in ``||math:Math||``, and replace the 0 in ``||sprites:set projectile y to 0||`` with the it.
 
@@ -158,7 +190,7 @@ game.onUpdateInterval(1000, function () {
 })
 ```
 
-## Step 7 @fullscreen
+## Step 8 @fullscreen
 
 Find ``||scene:screen height||`` in ``||scene:Scene||``. Replace the 10 in ``||math:pick random 0 to 10||`` with it.
 

--- a/docs/concepts/throw-a-bone.md
+++ b/docs/concepts/throw-a-bone.md
@@ -97,12 +97,12 @@ let projectile = sprites.createProjectile(img`
 . . . . 1 1 . . . . . . . . . .
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
-`, 0, 0, SpriteKind.Player)
+`, 0, 100, SpriteKind.Player)
 ```
 
 ## Step 3 @fullscreen
 
-In ``||sprites:projectile||``, set ``||sprites:vx||`` to 50. Then, run the game, and notice that the ``||variables:projectile||`` now starts on the **left** side of the screen, and moves to the right.
+In ``||sprites:projectile||``, set ``||sprites:vx||`` to 50. Then, run the game, and notice that the ``||variables:projectile||`` now starts on the **left** side of the screen, and moves down and to the right.
 
 ```blocks
 enum SpriteKind {
@@ -152,7 +152,7 @@ let projectile = sprites.createProjectile(img`
 . . . . 1 1 . . . . . . . . . .
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
-`, 50, 0, SpriteKind.Player)
+`, 50, 100, SpriteKind.Player)
 ```
 
 ## Step 4 @fullscreen
@@ -212,61 +212,6 @@ let projectile = sprites.createProjectile(img`
 
 ## Step 5 @fullscreen
 
-In ``||sprites:projectile||``, set ``||sprites:vy||`` to -15. Then, run the game, and notice that the ``||variables:projectile||`` now starts on the **bottom left** corner of the screen and moves up and to the right.
-
-```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
-let mySprite = sprites.create(img`
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . f f f f . . . . . . . . . . 
-. . . . . . . . f f 1 1 1 1 f f . . . . . . . . 
-. . . . . . . f b 1 1 1 1 1 1 b f . . . . . . . 
-. . . . . f f f c 1 1 1 1 1 1 1 f . . . . . . . 
-. . . f c 1 1 1 c d 1 1 1 1 1 1 1 f . . . . . . 
-. . . f 1 b 1 b 1 b 1 1 1 1 d d d f . . . . . . 
-. . . f b f b f f c f 1 1 f c d d f . . . . . . 
-. . . . . . f c f 1 1 1 1 1 1 b b f . . . . . . 
-. . . . . . . c c b d b 1 b 1 f c f . . . . . . 
-. . . . . . . f f f b f b f d f f . . . . . . . 
-. . . . . . . . f f f f f f f f . . . . . . . . 
-. . . . . . . . f f f f f f f f f f f . . . . . 
-. . . . . . . . . f f f f f c 1 1 1 c f . . . . 
-. . . . . . . . . f f f f f 1 b 1 b 1 f . . . . 
-. . . . . . . . . . f f f f b f b f b f . . . . 
-. . . . . . . . . . . f f f f . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-`, SpriteKind.Player)
-let projectile = sprites.createProjectile(img`
-. . . . . . . . . . . . . . . .
-. . . . . . . . . . . . . . . .
-. . . . . . . . . . 1 1 . . . .
-. . . . . . . . . 1 1 1 . . . .
-. . . . . . . . . 1 1 1 . . . .
-. . . . . . . . . 1 1 1 1 1 . .
-. . . . . . . 1 1 1 1 1 1 1 . .
-. . . . . . 1 1 1 1 . 1 1 1 . .
-. . 1 1 . 1 1 1 1 . . . . . . .
-. 1 1 1 1 1 1 . . . . . . . . .
-. 1 1 1 1 1 . . . . . . . . . .
-. . 1 1 1 1 . . . . . . . . . .
-. . . 1 1 1 . . . . . . . . . .
-. . . . 1 1 . . . . . . . . . .
-. . . . . . . . . . . . . . . .
-. . . . . . . . . . . . . . . .
-`, 50, -15, SpriteKind.Player)
-```
-
-## Step 6 @fullscreen
-
 Click on the **(+)** at the end of ``||sprites:projectile||``, and change ``||variables:item||`` to ``||variables:mySprite||``.
 
 This will cause the bone to be created at the same location as ``||variables:mySprite||``, no matter where that ``||sprites:sprite||`` is on the screen.
@@ -322,7 +267,7 @@ let projectile = sprites.createProjectile(img`
 `, 50, -15, SpriteKind.Player, mySprite)
 ```
 
-## Step 7 @fullscreen
+## Step 6 @fullscreen
 
 Find ``||controller:on any button pressed||`` in ``||controller:Controller||``, and drag it into the workspace. Drag ``||variables:set projectile to||`` from ``||loops:on start||`` into ``||controller:on any button pressed||``.
 
@@ -382,7 +327,7 @@ controller.anyButton.onEvent(ControllerButtonEvent.Pressed, function () {
 })
 ```
 
-## Step 8 @fullscreen
+## Step 7 @fullscreen
 
 In the ``||controller:on any button pressed||`` event, click on ``||controller:any||`` and change it to ``||controller:A||``.
 

--- a/docs/tutorials/happy-flower.md
+++ b/docs/tutorials/happy-flower.md
@@ -115,7 +115,7 @@ game.onUpdateInterval(500, function () {
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
-`, 0, 0, SpriteKind.Player)
+`, 0, 100, SpriteKind.Player)
 })
 ```
 
@@ -157,13 +157,14 @@ game.onUpdateInterval(500, function () {
 . . 5 5 5 5 . . 
 . . . . . . . . 
 . . . . . . . . 
-`, 0, 0, SpriteKind.Player)
+`, 0, 100, SpriteKind.Player)
 })
 ```
 
 ## Step 5
 
 Go get a ``||Math:pick random 0 to 10||``. Place it in the ``||sprites:vx||`` slot of ``||sprites:projectile||``. Change the `0` to `-25` and the `10` to `25`. 
+
 ```blocks
 enum SpriteKind {
     Player,
@@ -198,7 +199,7 @@ game.onUpdateInterval(500, function () {
 . . 5 5 5 5 . . 
 . . . . . . . . 
 . . . . . . . . 
-`, Math.randomRange(-25, 25), 0, SpriteKind.Player)
+`, Math.randomRange(-25, 25), 100, SpriteKind.Player)
 })
 ```
 

--- a/docs/tutorials/star-field.md
+++ b/docs/tutorials/star-field.md
@@ -43,7 +43,7 @@ game.onUpdate(function () {
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
-`, 0, 0, SpriteKind.Player)
+`, 0, 100, SpriteKind.Player)
 })
 ```
 
@@ -76,7 +76,7 @@ game.onUpdate(function () {
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
-`, 0, 0, SpriteKind.Player)
+`, 0, 100, SpriteKind.Player)
 })
 ```
 


### PR DESCRIPTION
fixes #422 

update concepts and tutorials to include the default value added recently added to projectiles (i.e. ``vy=100``)