### PR TITLE
Removed lesson card type to allow linking to docs

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -9,14 +9,12 @@
   "name": "Cherry Pickr",
   "description": "Learn the basics of creating a game",
   "url": "/lessons/cherry-pickr",
-  "cardType": "lesson",
   "imageUrl": "/static/lessons/cherry-pickr.png"
 },
 {
   "name": "Barrel Dodger",
   "description": "Use the sprite editor to make player, tile, and enemy images",
   "url": "/lessons/barrel-dodger",
-  "cardType": "lesson",
   "imageUrl": "/static/lessons/barrel-dodger.png"
 }
 ]


### PR DESCRIPTION
Removes the cardType of lessons so that they correctly link to the docs as suggested in Microsoft/pxt#5090

Fixes Microsoft/pxt-arcade#374