### PR TITLE
Save as .mkcd and move button to the menu

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -51,7 +51,6 @@
         "driveName": "ARCADE",
         "floatingPoint": true,
         "taggedInts": true,
-        "saveAsPNG": true,
         "nativeType": "thumb",
         "gc": true,
         "upgrades": [],
@@ -243,6 +242,7 @@
         },
         "monacoFieldEditors": ["image-editor"],
         "scriptManager": true,
+        "saveInMenu": true,
         "experiments": [
             "debugger"
         ]


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/443

We haven't decided on what the saving story should look like, so this PR is turning off save as PNG and moving the save button into the gearwheel.


Things to discuss about saving:
* Should we save as UF2? If so, how do you choose hardware and what if you have no hardware? 
* If we have WebUSB on, how do you save your project locally in a format that can be flashed onto the hardware?