### PR TITLE
Remove unneeded var declarations in examples

### DIFF
--- a/docs/examples/eater-princess.md
+++ b/docs/examples/eater-princess.md
@@ -14,104 +14,103 @@ let taco: Sprite = null
 let princess: Sprite = null
 let cherry: Sprite = null
 let tree: Sprite = null
-let otherSprite: Sprite = null
 /**
  * Eating tree or cherry gives 1 point
- * 
+ *
  * Eating taco gives 10 points
- * 
+ *
  * If you try to eat the death pill you will lose a life, but gain 15 points.
- * 
+ *
  * Princess, you have 60 seconds and 3 life to finish the game.
  */
 function randomAssets() {
     tree = sprites.create(img`
-. . . . . . . c c . . . . . . . 
-. . . . c c c 6 5 c 6 6 . . . . 
-. . . . c 6 c 5 5 c 7 6 . . . . 
-. . . 6 c c 7 5 5 7 c 6 6 . . . 
-. . c c 7 7 7 7 7 5 7 7 c 6 . . 
-. 6 6 6 c 6 7 7 7 7 6 c c 6 6 . 
-c 7 7 7 6 c 7 c 6 7 6 7 7 7 7 6 
-c c c 6 6 6 c 6 6 6 6 7 7 6 6 6 
-. c c 7 6 6 6 6 6 7 7 7 7 c 6 . 
-. c 7 7 6 6 7 6 6 7 7 6 7 7 c . 
-. c c c c 7 7 6 f 7 7 c c c c . 
-. . . . c 7 c f f c 7 c . . . . 
-. . . . . 6 f e e e c . . . . . 
-. . . . . e e e e e e . . . . . 
-. . . . e e . e e . e e . . . . 
-. . . . . . . e e . . . . . . . 
+. . . . . . . c c . . . . . . .
+. . . . c c c 6 5 c 6 6 . . . .
+. . . . c 6 c 5 5 c 7 6 . . . .
+. . . 6 c c 7 5 5 7 c 6 6 . . .
+. . c c 7 7 7 7 7 5 7 7 c 6 . .
+. 6 6 6 c 6 7 7 7 7 6 c c 6 6 .
+c 7 7 7 6 c 7 c 6 7 6 7 7 7 7 6
+c c c 6 6 6 c 6 6 6 6 7 7 6 6 6
+. c c 7 6 6 6 6 6 7 7 7 7 c 6 .
+. c 7 7 6 6 7 6 6 7 7 6 7 7 c .
+. c c c c 7 7 6 f 7 7 c c c c .
+. . . . c 7 c f f c 7 c . . . .
+. . . . . 6 f e e e c . . . . .
+. . . . . e e e e e e . . . . .
+. . . . e e . e e . e e . . . .
+. . . . . . . e e . . . . . . .
 `, SpriteKind.Food)
     tree.x = Math.randomRange(0, scene.screenWidth())
     tree.y = Math.randomRange(0, scene.screenHeight())
     cherry = sprites.create(img`
-. . . . . . . . . . . 6 6 6 6 6 
-. . . . . . . . . 6 6 7 7 7 7 8 
-. . . . . . 8 8 8 7 7 8 8 6 8 8 
-. . e e e e c 6 6 8 8 . 8 7 8 . 
-. e 2 5 4 2 e c 8 . . . 6 7 8 . 
-e 2 4 2 2 2 2 2 c . . . 6 7 8 . 
-e 2 2 2 2 2 2 2 c . . . 8 6 8 . 
-e 2 e e 2 2 2 2 e e e e c 6 8 . 
-c 2 e e 2 2 2 2 e 2 5 4 2 c 8 . 
-. c 2 e e e 2 e 2 4 2 2 2 2 c . 
-. . c 2 2 2 e e 2 2 2 2 2 2 2 e 
-. . . e c c e c 2 2 2 2 2 2 2 e 
-. . . . . . . c 2 e e 2 2 e 2 c 
-. . . . . . . c e e e e e e 2 c 
-. . . . . . . . c e 2 2 2 2 c . 
-. . . . . . . . . c c c c c . . 
+. . . . . . . . . . . 6 6 6 6 6
+. . . . . . . . . 6 6 7 7 7 7 8
+. . . . . . 8 8 8 7 7 8 8 6 8 8
+. . e e e e c 6 6 8 8 . 8 7 8 .
+. e 2 5 4 2 e c 8 . . . 6 7 8 .
+e 2 4 2 2 2 2 2 c . . . 6 7 8 .
+e 2 2 2 2 2 2 2 c . . . 8 6 8 .
+e 2 e e 2 2 2 2 e e e e c 6 8 .
+c 2 e e 2 2 2 2 e 2 5 4 2 c 8 .
+. c 2 e e e 2 e 2 4 2 2 2 2 c .
+. . c 2 2 2 e e 2 2 2 2 2 2 2 e
+. . . e c c e c 2 2 2 2 2 2 2 e
+. . . . . . . c 2 e e 2 2 e 2 c
+. . . . . . . c e e e e e e 2 c
+. . . . . . . . c e 2 2 2 2 c .
+. . . . . . . . . c c c c c . .
 `, SpriteKind.Food)
     cherry.x = Math.randomRange(0, scene.screenWidth())
     cherry.y = Math.randomRange(0, scene.screenHeight())
     if (Math.percentChance(20)) {
         taco = sprites.create(img`
-. . . . . . . e e e e . . . . . 
-. . . . . e e 4 5 5 5 e e . . . 
-. . . . e 4 5 6 2 2 7 6 6 e . . 
-. . . e 5 6 6 7 2 2 6 4 4 4 e . 
-. . e 5 2 2 7 6 6 4 5 5 5 5 4 . 
-. e 5 6 2 2 8 8 5 5 5 5 5 4 5 4 
-. e 5 6 7 7 8 5 4 5 4 5 5 5 5 4 
-e 4 5 8 6 6 5 5 5 5 5 5 4 5 5 4 
-e 5 c e 8 5 5 5 4 5 5 5 5 5 5 4 
-e 5 c c e 5 4 5 5 5 4 5 5 5 e . 
-e 5 c c 5 5 5 5 5 5 5 5 4 e . . 
-e 5 e c 5 4 5 4 5 5 5 e e . . . 
-e 5 e e 5 5 5 5 5 4 e . . . . . 
-4 5 4 e 5 5 5 5 e e . . . . . . 
-. 4 5 4 5 5 4 e . . . . . . . . 
-. . 4 4 e e e . . . . . . . . . 
+. . . . . . . e e e e . . . . .
+. . . . . e e 4 5 5 5 e e . . .
+. . . . e 4 5 6 2 2 7 6 6 e . .
+. . . e 5 6 6 7 2 2 6 4 4 4 e .
+. . e 5 2 2 7 6 6 4 5 5 5 5 4 .
+. e 5 6 2 2 8 8 5 5 5 5 5 4 5 4
+. e 5 6 7 7 8 5 4 5 4 5 5 5 5 4
+e 4 5 8 6 6 5 5 5 5 5 5 4 5 5 4
+e 5 c e 8 5 5 5 4 5 5 5 5 5 5 4
+e 5 c c e 5 4 5 5 5 4 5 5 5 e .
+e 5 c c 5 5 5 5 5 5 5 5 4 e . .
+e 5 e c 5 4 5 4 5 5 5 e e . . .
+e 5 e e 5 5 5 5 5 4 e . . . . .
+4 5 4 e 5 5 5 5 e e . . . . . .
+. 4 5 4 5 5 4 e . . . . . . . .
+. . 4 4 e e e . . . . . . . . .
 `, SpriteKind.Taco)
         taco.x = Math.randomRange(0, scene.screenWidth())
         taco.y = Math.randomRange(0, scene.screenHeight())
     } else {
         deathpill = sprites.create(img`
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . f f f f . . . . . . . . . . 
-. . . . . . . . f f 1 1 1 1 f f . . . . . . . . 
-. . . . . . . f b 1 1 1 1 1 1 b f . . . . . . . 
-. . . . . . . f 1 1 1 1 1 1 1 1 f . . . . . . . 
-. . . . . . f d 1 1 1 1 1 1 1 1 d f . . . . . . 
-. . . . 7 . f d 1 1 1 1 1 1 1 1 d f . . . . . . 
-. . . 7 . . f d 1 1 1 1 1 1 1 1 d f . . . . . . 
-. . . 7 . . f d 1 1 1 1 1 1 1 1 d f . . . . . . 
-. . . 7 . . f d d d 1 1 1 1 d d d f f . . . . . 
-. . . 7 7 . f b d b f d d f b d b f c f . . . . 
-. . . 7 7 7 f c d c f 1 1 f c d c f b f . . . . 
-. . . . 7 7 f f f b d b 1 b d f f c f . . . . . 
-. . . . f c b 1 b c f f f f f f . . . . . . . . 
-. . . . f 1 c 1 c 1 f f f f f f . . . . . . . . 
-. . . . f d f d f d f f f f f . . . . . . . . . 
-. . . . . f . f . f . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . . . . . . .
+. . . . . . . . . . f f f f . . . . . . . . . .
+. . . . . . . . f f 1 1 1 1 f f . . . . . . . .
+. . . . . . . f b 1 1 1 1 1 1 b f . . . . . . .
+. . . . . . . f 1 1 1 1 1 1 1 1 f . . . . . . .
+. . . . . . f d 1 1 1 1 1 1 1 1 d f . . . . . .
+. . . . 7 . f d 1 1 1 1 1 1 1 1 d f . . . . . .
+. . . 7 . . f d 1 1 1 1 1 1 1 1 d f . . . . . .
+. . . 7 . . f d 1 1 1 1 1 1 1 1 d f . . . . . .
+. . . 7 . . f d d d 1 1 1 1 d d d f f . . . . .
+. . . 7 7 . f b d b f d d f b d b f c f . . . .
+. . . 7 7 7 f c d c f 1 1 f c d c f b f . . . .
+. . . . 7 7 f f f b d b 1 b d f f c f . . . . .
+. . . . f c b 1 b c f f f f f f . . . . . . . .
+. . . . f 1 c 1 c 1 f f f f f f . . . . . . . .
+. . . . f d f d f d f f f f f . . . . . . . . .
+. . . . . f . f . f . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . . . . . . .
 `, SpriteKind.Enemy)
         deathpill.x = Math.randomRange(0, scene.screenWidth())
         deathpill.y = Math.randomRange(0, scene.screenHeight())
@@ -133,22 +132,22 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Taco, function (sprite, otherSpr
 info.setLife(3)
 info.startCountdown(60)
 princess = sprites.create(img`
-. . . . . . 5 . 5 . . . . . . . 
-. . . . . f 5 5 5 f f . . . . . 
-. . . . f 1 5 2 5 1 6 f . . . . 
-. . . f 1 6 6 6 6 6 1 6 f . . . 
-. . . f 6 6 f f f f 6 1 f . . . 
-. . . f 6 f f d d f f 6 f . . . 
-. . f 6 f d f d d f d f 6 f . . 
-. . f 6 f d 3 d d 3 d f 6 f . . 
-. . f 6 6 f d d d d f 6 6 f . . 
-. f 6 6 f 3 f f f f 3 f 6 6 f . 
-. . f f d 3 5 3 3 5 3 d f f . . 
-. . f d d f 3 5 5 3 f d d f . . 
-. . . f f 3 3 3 3 3 3 f f . . . 
-. . . f 3 3 5 3 3 5 3 3 f . . . 
-. . . f f f f f f f f f f . . . 
-. . . . . f f . . f f . . . . . 
+. . . . . . 5 . 5 . . . . . . .
+. . . . . f 5 5 5 f f . . . . .
+. . . . f 1 5 2 5 1 6 f . . . .
+. . . f 1 6 6 6 6 6 1 6 f . . .
+. . . f 6 6 f f f f 6 1 f . . .
+. . . f 6 f f d d f f 6 f . . .
+. . f 6 f d f d d f d f 6 f . .
+. . f 6 f d 3 d d 3 d f 6 f . .
+. . f 6 6 f d d d d f 6 6 f . .
+. f 6 6 f 3 f f f f 3 f 6 6 f .
+. . f f d 3 5 3 3 5 3 d f f . .
+. . f d d f 3 5 5 3 f d d f . .
+. . . f f 3 3 3 3 3 3 f f . . .
+. . . f 3 3 5 3 3 5 3 3 f . . .
+. . . f f f f f f f f f f . . .
+. . . . . f f . . f f . . . . .
 `, SpriteKind.Player)
 princess.setFlag(SpriteFlag.StayInScreen, true)
 controller.moveSprite(princess)

--- a/docs/examples/space-destroyer.md
+++ b/docs/examples/space-destroyer.md
@@ -11,8 +11,6 @@ enum SpriteKind {
 let ship: Sprite = null
 let projectile: Sprite = null
 let asteroids: Image[] = []
-let otherSprite: Sprite = null
-let sprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {
     game.over()
 })


### PR DESCRIPTION
`let sprite: Sprite = null` and `let otherSprite: Sprite = null` declarations are not necessary in example code if those variables are only used inside a sprite event. With the reporter changes, these declarations actually show up in the blocks as a gray block, so let's get rid of them. All our other examples don't have these declarations.

Tested on v0.2.35 (live) and latest master

Changes without whitespace: https://github.com/Microsoft/pxt-arcade/pull/487/files?w=1