### PR TITLE
Fix a few simulator layout edge cases

### DIFF
--- a/sim/controlPad.ts
+++ b/sim/controlPad.ts
@@ -134,6 +134,13 @@ namespace pxsim {
             }
         }
 
+        setVisible(visible: boolean) {
+            this.dPadRoot.setVisible(visible)
+            this.buttonsRoot.setVisible(visible);
+            this.menu.setVisible(visible);
+            this.reset.setVisible(visible);
+        }
+
         moveDPad(left: number, top: number, width: number) {
             this.dPadRoot.el.style.position = "absolute";
             this.dPadRoot.el.style.left = left + "px";

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -72,7 +72,7 @@ namespace pxsim {
      */
     export class Board extends pxsim.BaseBoard
         implements pxsim.MusicBoard
-        // , pxsim.JacDacBoard 
+        // , pxsim.JacDacBoard
         {
         public id: string;
         public bus: EventBus;
@@ -208,10 +208,21 @@ namespace pxsim {
 
         layout() {
             const minControlWidth = 100;
-            const menuResetWidth = minControlWidth * 0.7;
+            const maxThinButtonWidth = minControlWidth * 0.7;
 
             const maxWidth = document.body.clientWidth;
             const maxHeight = document.body.clientHeight;
+
+            if (maxWidth < 200 || maxHeight < 200) {
+                // Show no controls, we can barely fit the screen
+                this.view.bevelEdges = false;
+                this.controls.setVisible(false);
+                this.view.centerInBox(0, 0, this.view.getFit(maxWidth, maxHeight, 20));
+                return;
+            }
+
+            this.view.bevelEdges = !isIE();
+            this.controls.setVisible(true);
 
             const landscapeWidth = maxWidth - minControlWidth * 2;
             const portraitHeight = maxHeight - minControlWidth;
@@ -219,7 +230,7 @@ namespace pxsim {
             const portraitMetrics = this.view.getFit(maxWidth, portraitHeight, 20);
             const landscapeMetrics = this.view.getFit(landscapeWidth, maxHeight, 20);
 
-            if (portraitMetrics.area > landscapeMetrics.area) {
+            if (portraitMetrics.area >= landscapeMetrics.area) {
                 // Place controls below
                 this.view.centerInBox(0, 0, portraitMetrics);
                 const bb = this.view.boundingBox();
@@ -235,13 +246,17 @@ namespace pxsim {
                 this.controls.moveDPad(0, controlsTop, controlsHeight);
                 this.controls.moveButtons(maxWidth - controlsHeight, controlsTop, controlsHeight);
 
-                const spacing = 30;
-                const menuResetTop = bb.bottom + 20;
+                const menuResetTop = bb.bottom + 10;
+
+                // 0.1575 is the ratio of padding / height in the D-PAD and A-B SVGs.
+                const thinButtonWidth = Math.min(maxThinButtonWidth, (controlsTop - menuResetTop + controlsHeight * 0.1575) / MENU_RESET_ASPECT_RATIO);
+                const spacing = thinButtonWidth / 4;
+
                 const midpoint = maxWidth / 2;
 
                 // Centered between the d-pad and buttons
-                this.controls.moveReset(midpoint - (spacing / 2) - menuResetWidth, menuResetTop, menuResetWidth);
-                this.controls.moveMenu(midpoint + (spacing / 2), menuResetTop, menuResetWidth);
+                this.controls.moveReset(midpoint - (spacing / 2) - thinButtonWidth, menuResetTop, thinButtonWidth);
+                this.controls.moveMenu(midpoint + (spacing / 2), menuResetTop, thinButtonWidth);
             }
             else {
                 // Place controls on sides
@@ -251,8 +266,8 @@ namespace pxsim {
                 this.controls.moveDPad(0, maxHeight - bb.left, bb.left);
                 this.controls.moveButtons(maxWidth - bb.left, maxHeight - bb.left, bb.left);
 
-                this.controls.moveReset(bb.left - menuResetWidth - 20, bb.top, menuResetWidth);
-                this.controls.moveMenu(bb.right + 20, bb.top, menuResetWidth)
+                this.controls.moveReset(bb.left - maxThinButtonWidth - 20, bb.top, maxThinButtonWidth);
+                this.controls.moveMenu(bb.right + 20, bb.top, maxThinButtonWidth)
             }
         }
     }
@@ -276,6 +291,8 @@ namespace pxsim {
         private cachedWidth: number;
         private cachedHeight: number;
         private cachedPalette: Uint32Array;
+
+        bevelEdges = true;
 
         private ox: number;
         private oy: number;
@@ -364,6 +381,11 @@ namespace pxsim {
         }
 
         protected calculateClipPath(width: number, height: number, borderWidth: number) {
+            if (!this.bevelEdges) {
+                this.canvas.style.clipPath = null;
+                return;
+            }
+
             let points = [];
             const wedgeOffset = borderWidth * 2 / 3;
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/444
Fixes https://github.com/Microsoft/pxt-arcade/issues/295
Fixes https://github.com/Microsoft/pxt-arcade/issues/288
Fixes https://github.com/Microsoft/pxt-arcade/issues/412

This PR does the following:

1. Make the menu/reset buttons scale their size and padding
2. Hide the controls in tablet view (so you just see the screen)
3. Remove the screen bevels in Internet Explorer

