### PR TITLE
Limit hardware screen to 120px high

### DIFF
--- a/libs/screen---st7735/targetoverrides.ts
+++ b/libs/screen---st7735/targetoverrides.ts
@@ -7,9 +7,8 @@ function img(lits: any, ...args: any[]): Image { return null }
 
 // set palette before creating screen, so the JS version has the right BPP
 image.setPalette(hex`__palette`)
-let screen = image.create(
-    control.getConfigValue(DAL.CFG_DISPLAY_WIDTH, 160), 
-    control.getConfigValue(DAL.CFG_DISPLAY_HEIGHT, 128))
+//% whenUsed
+const screen = _screen_internal.createScreen();
 
 namespace image {
     //% shim=pxt::setPalette
@@ -22,8 +21,26 @@ namespace _screen_internal {
     //% shim=pxt::updateStats
     function updateStats(msg: string): void { }
 
-    control.__screen.setupUpdate(() => updateScreen(screen))
-    control.EventContext.onStats = function (msg: string) {
-        updateStats(msg);
+    //% shim=pxt::updateScreenStatusBar
+    function updateScreenStatusBar(img: Image): void { }
+    //% shim=pxt::setupScreenStatusBar
+    function setupScreenStatusBar(barHeight: int32): void { }
+
+    export function createScreen() {
+        const img = image.create(160, 120);
+        setupScreenStatusBar(8);
+
+        const status = image.create(160, 8)
+
+        control.__screen.setupUpdate(() => updateScreen(img))
+        control.EventContext.onStats = function (msg: string) {
+            status.fill(0)
+            status.print(msg, 2, 2, 1, image.font5)
+            updateScreenStatusBar(status)
+            updateStats(msg);
+        }
+
+        return img;
     }
+
 }

--- a/libs/screen---st7735/targetoverrides.ts
+++ b/libs/screen---st7735/targetoverrides.ts
@@ -31,6 +31,7 @@ namespace _screen_internal {
         setupScreenStatusBar(8);
 
         const status = image.create(160, 8)
+        updateScreenStatusBar(status) // clear the status area
 
         control.__screen.setupUpdate(() => updateScreen(img))
         control.EventContext.onStats = function (msg: string) {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "typescript": "2.6.1"
   },
   "dependencies": {
-    "pxt-common-packages": "6.0.7",
-    "pxt-core": "5.3.8"
+    "pxt-common-packages": "6.0.8",
+    "pxt-core": "5.3.10"
   },
   "scripts": {
     "serve": "node node_modules/pxt-core/built/pxt.js serve"

--- a/sim/public/sim.css
+++ b/sim/public/sim.css
@@ -70,6 +70,10 @@ canvas {
     left: 5%;
     color: #3c3cff;
     font-size: 11px;
+    -webkit-user-select: none; /* Safari 3.1+ */
+    -moz-user-select: none; /* Firefox 2+ */
+    -ms-user-select: none; /* IE 10+ */
+     user-select: none; /* Standard syntax */
 }
 
 #controls {

--- a/sim/public/sim.css
+++ b/sim/public/sim.css
@@ -64,6 +64,14 @@ canvas {
     width: 100%;
 }
 
+#debug-stats {
+    position: absolute;
+    bottom: 1.5%;
+    left: 5%;
+    color: #3c3cff;
+    font-size: 11px;
+}
+
 #controls {
     position: absolute;
     width: 100%;

--- a/sim/public/simulator.html
+++ b/sim/public/simulator.html
@@ -29,6 +29,7 @@
 
 <body id="root" class="blur">
     <div id="wrap">
+        <div id="debug-stats"></div>
         <div id="screen-back"></div>
         <div id="screen">
             <div id="paint-surface-container">

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -58,6 +58,7 @@ namespace pxsim {
         public background: HTMLDivElement;
         public controlsDiv: HTMLDivElement;
         public canvas: HTMLCanvasElement;
+        public stats: HTMLElement;
         public screen: Uint32Array;
         public startTime = Date.now()
         public screenState: ScreenState
@@ -158,6 +159,8 @@ namespace pxsim {
             this.runOptions = msg;
             this.background = document.getElementById("screen-back") as HTMLDivElement;
             this.canvas = document.getElementById("paint-surface") as HTMLCanvasElement;
+            this.stats = document.getElementById("debug-stats");
+            this.stats.className = "stats"
             this.canvas.width = 16;
             this.canvas.height = 16;
             this.id = msg.id;
@@ -182,6 +185,7 @@ namespace pxsim {
         }
 
         updateStats() {
+            this.stats.textContent = this.screenState.stats;
             this.tryScreenshot();
         }
 


### PR DESCRIPTION
Use the bottom 8 pixels for displaying stats when requested from menu. Use the old overlay text element in simulator.

Requires https://github.com/Microsoft/pxt-common-packages/pull/633

Fixes https://github.com/Microsoft/pxt-arcade/issues/542
