### PR TITLE
always focus on keystroke

### DIFF
--- a/sim/controlPad.ts
+++ b/sim/controlPad.ts
@@ -63,7 +63,11 @@ namespace pxsim {
             let inside: KeyBinding = null
             let close: KeyBinding[] = []
 
-            if (!document.hasFocus()) window.focus();
+            // IE bug: it seems that IE does not maintain the focus state properly
+            //         harmless to request focus on each keystroke
+            //if (!document.hasFocus()) {
+            window.focus();
+            //}
 
             const x = ev.pageX
             const y = ev.pageY


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-arcade/issues/438

It seems that IE gets it's "focus" state messed up.