### PR TITLE
(do not merge yet) game over in docs and upgrade rules

### DIFF
--- a/docs/concepts/princess-pizza.md
+++ b/docs/concepts/princess-pizza.md
@@ -320,7 +320,7 @@ enum SpriteKind {
 let pizza: Sprite = null
 let princess: Sprite = null
 sprites.onOverlap(SpriteKind.Enemy, SpriteKind.Player, function (sprite, otherSprite) {
-    game.over()
+    game.over(false)
 })
 princess = sprites.create(img`
 . . . . . f f 4 4 f f . . . . . 

--- a/docs/courses/csintro1/loops/projectiles.md
+++ b/docs/courses/csintro1/loops/projectiles.md
@@ -164,7 +164,7 @@ enum SpriteKind {
 let projectile: Sprite = null
 let mySprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
-    game.over()
+    game.over(false)
 })
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro1/review/paparazzi.md
+++ b/docs/courses/csintro1/review/paparazzi.md
@@ -85,7 +85,7 @@ Collette wants to add in a splash screen that shows the score the player reached
 ```blocks
 info.onCountdownEnd(function () {
     game.splash("")
-    game.over()
+    game.over(false)
 })
 ```
 

--- a/docs/courses/csintro2/functions/redundancy.md
+++ b/docs/courses/csintro2/functions/redundancy.md
@@ -202,7 +202,7 @@ pause(500)
 music.playTone(262, music.beat(BeatFraction.Half))
 pause(500)
 pause(2000)
-game.over()
+game.over(false)
 ```
 
 ## Student Task #2: Events

--- a/docs/courses/csintro2/logic/intro.md
+++ b/docs/courses/csintro2/logic/intro.md
@@ -68,7 +68,7 @@ sprites.onDestroyed(SpriteKind.Enemy, function (sprite) {
     info.changeScoreBy(1)
 })
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {
-    game.over()
+    game.over(false)
 })
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/examples/asteroids.md
+++ b/docs/examples/asteroids.md
@@ -64,7 +64,7 @@ const rocketImg = img`
 `
 
 spaceship.onOverlap(function (other: Sprite) {
-    game.over()
+    game.over(false)
 })
 spaceship.z = 10
 

--- a/docs/examples/bouncer-bucket.md
+++ b/docs/examples/bouncer-bucket.md
@@ -125,7 +125,7 @@ sprites.onOverlap(SpriteKind.Ball, SpriteKind.Player, function (sprite, otherSpr
 })
 info.onCountdownEnd(function () {
     playing = false
-    game.over()
+    game.over(false)
 })
 sprites.onDestroyed(SpriteKind.Ball, function (sprite) {
     for (let j = 0; j <= bouncers.length - 1; j++) {

--- a/docs/examples/car-race.md
+++ b/docs/examples/car-race.md
@@ -51,7 +51,7 @@ ddx = 1
 const road = sprites.create(roadImg)
 
 car.onOverlap(function (other: Sprite) {
-    game.over()
+    game.over(false)
 })
 car.z = 10
 

--- a/docs/examples/dodge-rock.md
+++ b/docs/examples/dodge-rock.md
@@ -10,7 +10,7 @@ enum SpriteKind {
 let projectile: Sprite = null
 let sprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
-    game.over()
+    game.over(false)
 })
 sprite = sprites.create(img`
 4 4 4 4 4 4 4 4

--- a/docs/examples/duck.md
+++ b/docs/examples/duck.md
@@ -23,7 +23,7 @@ controller.anyButton.onEvent(ControllerButtonEvent.Pressed, function () {
     animation.setAction(mySprite, ActionKind.Jumping)
 })
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
-    game.over()
+    game.over(false)
 })
 scene.setBackgroundColor(9)
 mySprite = sprites.create(img`
@@ -525,7 +525,7 @@ game.onUpdate(function () {
         animation.setAction(mySprite, ActionKind.Idle)
     }
     if (mySprite.bottom > 120 || mySprite.top < 0) {
-        game.over()
+        game.over(false)
     }
 })
 

--- a/docs/examples/food-machine.md
+++ b/docs/examples/food-machine.md
@@ -203,7 +203,7 @@ game.onUpdateInterval(500, function () {
             } else {
                 info.setScore(0)
             }
-            game.over()
+            game.over(false)
         }
     }
 })

--- a/docs/examples/guess-the-letter.md
+++ b/docs/examples/guess-the-letter.md
@@ -26,6 +26,6 @@ while (info.life() > 0) {
         }
     }
 }
-game.over()
+game.over(false)
 
 ```

--- a/docs/examples/jumper.md
+++ b/docs/examples/jumper.md
@@ -67,7 +67,7 @@ player.x = 20;
 player.y = ground;
 
 player.onOverlap(function (other: Sprite) {
-    game.over();
+    game.over(false);
 });
 
 

--- a/docs/examples/mega-bounce.md
+++ b/docs/examples/mega-bounce.md
@@ -47,7 +47,7 @@ game.onUpdate(function () {
         if (ball.right > screen.width || ball.left < 0)
             ball.vx = -ball.vx;
         if (ball.y > screen.height)
-            game.over();
+            game.over(false);
         if (counter % 10 == 0)
             ball.ay++;
     }

--- a/docs/examples/runner.md
+++ b/docs/examples/runner.md
@@ -73,7 +73,7 @@ game.onUpdate(function () {
         jumper.vy = -100
 
     if (jumper.y > screen.height)
-        game.over()
+        game.over(false)
     if (currHouse.right + gap < screen.width)
         newHouse()
 })

--- a/docs/examples/snake.md
+++ b/docs/examples/snake.md
@@ -102,7 +102,7 @@ game.onPaint(function () {
             n = (x << 8) | y
         }
         if (snake.indexOf(n) >= 0 || isEdge(x, y)) {
-            game.over()
+            game.over(false)
             return
         }
         snake.unshift(n)

--- a/docs/examples/space-destroyer.md
+++ b/docs/examples/space-destroyer.md
@@ -12,7 +12,7 @@ let ship: Sprite = null
 let projectile: Sprite = null
 let asteroids: Image[] = []
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {
-    game.over()
+    game.over(false)
 })
 sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Enemy, function (sprite, otherSprite) {
     sprite.destroy()

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -61,6 +61,12 @@
                     "controller\\.controlSprite": "controller.moveSprite",
                     "controller\\.controlPlayer": "controller.movePlayer"
                 }
+            }],
+            "0.0.0 - 0.3.24": [{
+                "type": "api",
+                "map": {
+                    "game\\.over\\(\\)": "game.over(false)"
+                }
             }]
         }
     },

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -67,6 +67,11 @@
                 "map": {
                     "game\\.over\\(\\)": "game.over(false)"
                 }
+            }, {
+                "type": "api",
+                "map": {
+                    "sprites\\.createEmptySprite\\(([^)]+)\\)": "sprites.create(img`1`, $1)"
+                }
             }]
         }
     },


### PR DESCRIPTION
update examples that use ``game.over`` and add a few upgrade rules. Will continue to add some more upgrades as I notice them from https://github.com/Microsoft/pxt-arcade/issues/587, but posting in case anyone knows what I'm missing:

The game over patch in pxtarget works well for typescript, but isn't properly represented in blocks until you go to typescript and force a decompilation back to blocks:

![2019-01-15 23 43 58](https://user-images.githubusercontent.com/5615930/51233791-b4d43f00-191f-11e9-9df2-f3c6b4d5a0f2.gif)

notice the missing toggle before forcing decompilation, even though in typescript it properly switched from ``game.over()`` to ``game.over(false)``

any ideas on why this might be? 