### PR TITLE
Repairing Reset button

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "pxt-common-packages": "6.1.11",
-    "pxt-core": "5.4.14"
+    "pxt-core": "5.4.12"
   },
   "scripts": {
     "serve": "node node_modules/pxt-core/built/pxt.js serve"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "typescript": "2.6.1"
   },
   "dependencies": {
-    "pxt-common-packages": "6.1.10",
-    "pxt-core": "5.4.11"
+    "pxt-common-packages": "6.1.11",
+    "pxt-core": "5.4.14"
   },
   "scripts": {
     "serve": "node node_modules/pxt-core/built/pxt.js serve"

--- a/sim/api.ts
+++ b/sim/api.ts
@@ -19,7 +19,8 @@ namespace pxsim {
 
         // system keys
         Screenshot = -1,
-        Gif = -2
+        Gif = -2,
+        Reset = -3
     }
 
     export function mapKey(which: number): Key {

--- a/sim/controlPad.ts
+++ b/sim/controlPad.ts
@@ -147,6 +147,18 @@ namespace pxsim {
             return false;
         }
 
+        public init() {
+            const down = false;
+            this.setOverlayState(this.left, down);
+            this.setOverlayState(this.up, down);
+            this.setOverlayState(this.right, down);
+            this.setOverlayState(this.down, down);
+            this.setOverlayState(this.primary, down);
+            this.setOverlayState(this.secondary, down);
+            this.setOverlayState(this.menu, down);
+            this.setOverlayState(this.reset, down);
+        }
+
         public mirrorKey(key: Key, down: boolean, realEvent?: boolean) {
             switch (key) {
                 case Key.Up:
@@ -166,6 +178,12 @@ namespace pxsim {
                     break;
                 case Key.B:
                     this.setOverlayState(this.secondary, down);
+                    break;
+                case Key.Menu:
+                    this.setOverlayState(this.menu, down);
+                    break;
+                case Key.Reset:
+                    this.setOverlayState(this.reset, down);
                     break;
                 default:
                     break;
@@ -222,12 +240,7 @@ namespace pxsim {
             this.drawMenuReset(this.reset, svg.resetButton);
             this.drawMenuReset(this.menu, svg.menuButton);
 
-            this.reset.el.addEventListener("click", () => {
-                pxsim.Runtime.postMessage(<pxsim.SimulatorCommandMessage>{
-                    type: "simulator",
-                    command: "restart"
-                })
-            });
+            this.bindPadEvents(this.reset, Key.Reset, 0.1);
             this.bindPadEvents(this.menu, Key.Menu, 0.25);
 
             this.moveDPad(0, 0, COMPONENT_WIDTH)
@@ -306,7 +319,7 @@ namespace pxsim {
             return overlay;
         }
 
-        protected setOverlayState(overlay: s.Rect | s.Circle, down: boolean) {
+        protected setOverlayState(overlay: s.Rect | s.Circle | s.SVG, down: boolean) {
             if (down) {
                 overlay.setClass("controller-button-overlay pressed");
             }

--- a/sim/controlPad.ts
+++ b/sim/controlPad.ts
@@ -155,8 +155,8 @@ namespace pxsim {
             this.setOverlayState(this.down, down);
             this.setOverlayState(this.primary, down);
             this.setOverlayState(this.secondary, down);
-            this.setOverlayState(this.menu, down);
-            this.setOverlayState(this.reset, down);
+            //this.setOverlayState(this.menu, down);
+            //this.setOverlayState(this.reset, down);
         }
 
         public mirrorKey(key: Key, down: boolean, realEvent?: boolean) {
@@ -179,12 +179,12 @@ namespace pxsim {
                 case Key.B:
                     this.setOverlayState(this.secondary, down);
                     break;
-                case Key.Menu:
-                    this.setOverlayState(this.menu, down);
-                    break;
-                case Key.Reset:
-                    this.setOverlayState(this.reset, down);
-                    break;
+                //case Key.Menu:
+                //    this.setOverlayState(this.menu, down);
+                //    break;
+                //case Key.Reset:
+                //    this.setOverlayState(this.reset, down);
+                //    break;
                 default:
                     break;
             }

--- a/sim/controlPad.ts
+++ b/sim/controlPad.ts
@@ -27,14 +27,14 @@ namespace pxsim {
             const idx = this.pointerIds.indexOf(id);
             if (down && idx < 0) {
                 this.pointerIds.push(id);
-                console.log(`key ${this.key} down pointer ${idx} ${this.pointerIds.length}`)
+                //console.log(`key ${this.key} down pointer ${idx} ${this.pointerIds.length}`)
                 if (b && this.pointerIds.length == 1) { // first touch event
                     b.handleKeyEvent(this.key, true);
                 }
             }
             else if (!down && idx > -1) {
                 this.pointerIds.splice(idx, 1);
-                console.log(`key ${this.key} up pointer ${idx} ${this.pointerIds.length}`)
+                //console.log(`key ${this.key} up pointer ${idx} ${this.pointerIds.length}`)
                 if(b && !this.pointerIds.length) // last touch event
                     b.handleKeyEvent(this.key, false);
             }

--- a/sim/public/sim.css
+++ b/sim/public/sim.css
@@ -97,6 +97,16 @@ canvas {
     filter: grayscale();
 }
 
+.no-select {
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none;   /* Chrome/Safari/Opera */
+    -khtml-user-select: none;    /* Konqueror */
+    -moz-user-select: none;      /* Firefox */
+    -ms-user-select: none;       /* Internet Explorer/Edge */
+    user-select: none;           /* Non-prefixed version, currently
+                                    not supported by any browser */
+}
+
 .stats {
     margin-top: 8px;
 }

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -104,6 +104,13 @@ namespace pxsim {
         handleKeyEvent(key: Key, isPressed: boolean) {
             // handle system keys
             switch (key) {
+                case Key.Reset:
+                    if (isPressed)
+                        pxsim.Runtime.postMessage(<pxsim.SimulatorCommandMessage>{
+                            type: "simulator",
+                            command: "restart"
+                        })
+                    break;
                 case Key.Screenshot:
                     if (isPressed)
                         Runtime.postScreenshotAsync().done();
@@ -121,7 +128,7 @@ namespace pxsim {
                 this.controls.mirrorKey(key, isPressed);
         }
 
-        
+
         screenshotAsync(): Promise<ImageData> {
             const cvs = this.view.canvas;
             const ctx = this.view.context;
@@ -153,6 +160,7 @@ namespace pxsim {
                 }
             }
 
+            this.controls.init();
             this.view = new ScreenView(this.screenState, this.canvas, () => this.layout(), () => this.updateStats());
             this.layout()
 

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -110,7 +110,7 @@ namespace pxsim {
                             type: "simulator",
                             command: "restart"
                         })
-                    break;
+                    return;
                 case Key.Screenshot:
                     if (isPressed)
                         Runtime.postScreenshotAsync().done();

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -145,7 +145,7 @@ namespace pxsim {
             this.background = document.getElementById("screen-back") as HTMLDivElement;
             this.canvas = document.getElementById("paint-surface") as HTMLCanvasElement;
             this.stats = document.getElementById("debug-stats");
-            this.stats.className = "stats"
+            this.stats.className = "stats no-select"
             this.canvas.width = 16;
             this.canvas.height = 16;
             this.id = msg.id;


### PR DESCRIPTION
The "reset" button used to handle a click on the SVG element. Since we swallow all mouse/touch events, it wasn't being triggered anymore. Making it a proper control pad button with multi-touch and all.