### PR TITLE
Update package lock becausd sim is now optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,9 @@
       }
     },
     "acorn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.6.tgz",
+      "integrity": "sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -886,9 +886,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000932",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000932.tgz",
-      "integrity": "sha512-nc4jIhwpajQCvADmBo3F1fj8ySvE2+dw0lXAmYmtYJi1l7CvfdZVTkrwD60SrQHDC1mddgYtLyAcwrtYVtiMSQ=="
+      "version": "1.0.30000933",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000933.tgz",
+      "integrity": "sha512-DdIlPHIGtjUS2sH/yioeS9CS0JsWk8zGqid0OdfYhwJvufYZKZPcgerEX9E7PWOnshDc9IndnEJDoqauv+JUHA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1570,9 +1570,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.108",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.108.tgz",
-      "integrity": "sha512-/QI4hMpAh48a1Sea6PALGv+kuVne9A2EWGd8HrWHMdYhIzGtbhVVHh6heL5fAzGaDnZuPyrlWJRl8WPm4RyiQQ=="
+      "version": "1.3.111",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.111.tgz",
+      "integrity": "sha512-I2QjmmxWULp89fEHlFwRpKXSw4Y/Igo3u41py4MkzJTrgDOf/S4oq/IMuTUHze/5TTPpwem74oQiPMEgFtuDRA=="
     },
     "elliptic": {
       "version": "6.4.1",
@@ -5437,21 +5437,22 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "pxt-arcade-sim": {
-      "version": "git+https://github.com/Microsoft/pxt-arcade-sim.git#8d3641ecec6d355d1f51029f4dae6c8a518dadd9",
-      "from": "git+https://github.com/Microsoft/pxt-arcade-sim.git#v0.6.0"
+      "version": "0.6.1",
+      "resolved": "git+https://github.com/Microsoft/pxt-arcade-sim.git#dbdc85efab53c5f7222c977614cb769996b91f78",
+      "optional": true
     },
     "pxt-common-packages": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/pxt-common-packages/-/pxt-common-packages-6.1.11.tgz",
-      "integrity": "sha512-Q2e+kI8eC1HG7OPw0E+pD9Eec1NUAu7XfvItuoZjyKoKaIu93JkkrSKPu5If4MngjDA8kwkGdD+55Z5IIMrPEw==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/pxt-common-packages/-/pxt-common-packages-6.1.19.tgz",
+      "integrity": "sha512-wvz98Q+z+i5fxHQQ233M1bfS/N3RsESwABIcGvIdCm5FPO4FZCi9LsyWKmoDVKV+sQnhSOGN2wvl/FZ7GzxHSA==",
       "requires": {
         "pxt-core": "^5.3.10"
       }
     },
     "pxt-core": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/pxt-core/-/pxt-core-5.4.14.tgz",
-      "integrity": "sha512-6Rsv7S6AORwjaVCUe1ukUM2K6aaLvdD7fFpan4EYL3aCPuKCnXcJ328HKuh1U5IR7xG3S2cIoC4E/0IUnfwijA==",
+      "version": "5.4.23",
+      "resolved": "https://registry.npmjs.org/pxt-core/-/pxt-core-5.4.23.tgz",
+      "integrity": "sha512-7hBqbfAI66GnqE/wf9XRN1tI2ylu/gCgh2Sz+UsGRAuteFwHQ9IiFIJw7Yd9AFLCEP0sherxryNxOLsDlGba3Q==",
       "requires": {
         "applicationinsights-js": "^1.0.20",
         "bluebird": "3.5.1",


### PR DESCRIPTION
We made the sim optional in package.json but never updated the package-lock.json. As a result, npm was ignoring the optional setting.

Should fix https://github.com/Microsoft/pxt-arcade/issues/698

Hurray for package lock!