### PR TITLE
use github shortcut syntax for sim install

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pxt-core": "5.5.4"
   },
   "optionalDependencies": {
-    "pxt-arcade-sim": "git+https://github.com/Microsoft/pxt-arcade-sim.git#v0.6.1"
+    "pxt-arcade-sim": "Microsoft/pxt-arcade-sim.git#v0.6.1"
   },
   "scripts": {
     "serve": "node node_modules/pxt-core/built/pxt.js serve"


### PR DESCRIPTION
I was getting authentication errors on installing through https (sound like I forgot to set up git credentials manager), and https://github.com/npm/npm/issues/11567 had a suggestion to use the 'github shortcut syntax', which will try https, ssh, and git for authentication before failing