### PR TITLE
Add default arg name for sprite types

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -204,7 +204,8 @@
             "extraFunctionEditorTypes": [
                 {
                     "typeName": "Sprite",
-                    "icon": "send"
+                    "icon": "send",
+                    "defaultName": "mySprite"
                 }
             ]
         },


### PR DESCRIPTION
Requires https://github.com/Microsoft/pxt-blockly/pull/199 and a bump to latest pxt-core for this to take effect