### PR TITLE
Make the [+] button add an arbitrary new file, not custom.ts

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -241,6 +241,7 @@
         "betaUrl": "https://github.com/Microsoft/pxt-arcade",
         "githubUrl": "https://github.com/Microsoft/pxt-arcade",
         "boardName": "Arcade",
+        "addNewTypeScriptFile": true,
         "docMenu": [
             {
                 "name": "Docs",


### PR DESCRIPTION
Maybe this should be default for all targets, but for sure for new ones - custom.ts is replaced by packages.