### PR TITLE
add false as param so blocks `set tile` decompile w/ field editor

### DIFF
--- a/docs/concepts/setting-the-scene.md
+++ b/docs/concepts/setting-the-scene.md
@@ -76,7 +76,7 @@ scene.setTile(5, img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
-`)
+`, false)
 ```
 
 ## Step 4 @fullscreen
@@ -113,7 +113,7 @@ scene.setTile(5, img`
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
-`)
+`, false)
 ```
 
 ## Step 5 @fullscreen
@@ -155,7 +155,7 @@ scene.setTile(5, img`
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
-`)
+`, false)
 mySprite = sprites.create(img`
 . . . . . . f f f f . . . . . . 
 . . . . f f f 2 2 f f f . . . . 
@@ -217,7 +217,7 @@ scene.setTile(5, img`
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
 5 5 5 5 4 4 4 4 5 5 5 5 4 4 4 4 
-`)
+`, false)
 mySprite = sprites.create(img`
 . . . . . . f f f f . . . . . . 
 . . . . f f f 2 2 f f f . . . . 

--- a/docs/courses/csintro2/tilemap/intro.md
+++ b/docs/courses/csintro2/tilemap/intro.md
@@ -84,7 +84,7 @@ scene.setTile(5, img`
 5 5 5 a a a a a a a a a a a a a 
 5 5 a a a a a a a a a a a a a a 
 5 a a a a a a a a a a a a a a a 
-`)
+`, false)
 ```
 
 ## Student Task #2: Add tile to tile map
@@ -130,7 +130,7 @@ f f f f f f f f f f f f f f f f
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
-`)
+`, false)
 scene.setTile(3, img`
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
@@ -148,7 +148,7 @@ f f f f 1 1 1 1 1 1 1 f f f f f
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
-`)
+`, false)
 scene.setTile(6, img`
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
@@ -166,7 +166,7 @@ f f f f f f f f f f f f f f f f
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
-`)
+`, false)
 scene.setTile(5, img`
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
@@ -184,7 +184,7 @@ f f f f 1 1 1 1 1 1 1 f f f f f
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
-`)
+`, false)
 scene.setTile(4, img`
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
@@ -202,7 +202,7 @@ f f f f f f f f f f f f f f f f
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
-`)
+`, false)
 scene.setTile(7, img`
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
@@ -220,7 +220,7 @@ f f f f f f f f f f f f f f f f
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
-`)
+`, false)
 scene.setTile(8, img`
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
@@ -238,7 +238,7 @@ f f f f f f f f f f f f f f f f
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
 f f f f f f f f f f f f f f f f 
-`)
+`, false)
 ```
 
 In this example, the tiles are changed to correspond to images with letters on them.

--- a/docs/courses/csintro3/structure/tilemaps.md
+++ b/docs/courses/csintro3/structure/tilemaps.md
@@ -51,7 +51,7 @@ scene.setTileMap(img`
 . . . 1 1 1 . . . . 
 . . . . . . . . . . 
 `);
-scene.setTile(1, sprites.castle.tileGrass1);
+scene.setTile(1, sprites.castle.tileGrass1, false);
 ```
 
 This function accepts an ``index`` of a color,
@@ -101,7 +101,7 @@ scene.setTile(5, img`
 5 5 5 f 5 5 5 5 5 5 5 5 5 5 5 5 
 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
-`);
+`, false);
 scene.setTile(13, img`
 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
 5 f 5 5 5 5 5 5 5 5 5 f 5 5 5 5 
@@ -119,7 +119,7 @@ scene.setTile(13, img`
 8 8 8 9 9 6 8 6 6 8 8 8 8 8 8 8 
 8 8 8 9 6 6 8 8 8 8 8 8 8 8 8 8 
 8 8 9 9 8 8 8 8 8 8 8 8 8 8 8 8 
-`);
+`, false);
 scene.setTile(8, img`
 8 8 8 8 8 9 9 9 8 8 8 8 8 8 8 8 
 8 8 8 8 9 9 6 6 8 8 8 8 8 8 8 8 
@@ -137,7 +137,7 @@ scene.setTile(8, img`
 8 8 6 8 8 8 8 8 8 8 9 6 8 8 8 8 
 8 8 8 8 8 8 8 8 8 8 6 8 8 8 8 8 
 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 
-`);
+`, false);
 ```
 
 ## Student Task #1: Starter Scene
@@ -211,7 +211,7 @@ f 7 7 7 7 7 7 7 7 7 7 7 7 7 7 f
 f f f f f f f f f f f f f f f f 
 `);
 scene.setTile(15, sprites.castle.rock0, true);
-scene.setTile(7, sprites.castle.tileGrass1);
+scene.setTile(7, sprites.castle.tileGrass1, false);
 ```
 
 ### ~hint

--- a/docs/examples/cube-land.md
+++ b/docs/examples/cube-land.md
@@ -410,11 +410,11 @@ function level1Setup() {
         . . . . . . . . . . . . . . . . . . . . . . . 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9
     `);
     scene.setTile(9, projectImages.Stone, true);
-    scene.setTile(6, projectImages.Gate);
-    scene.setTile(3, projectImages.Boy);
-    scene.setTile(2, projectImages.Flower);
-    scene.setTile(1, projectImages.Flower_2);
-    scene.setTile(4, projectImages.Flag);
+    scene.setTile(6, projectImages.Gate, false);
+    scene.setTile(3, projectImages.Boy, false);
+    scene.setTile(2, projectImages.Flower, false);
+    scene.setTile(1, projectImages.Flower_2, false);
+    scene.setTile(4, projectImages.Flag, false);
     boySprite.setPosition(398, 268);
     girlSprite.setPosition(30, 200);
     boss1Sprite.setPosition(360, 178);
@@ -477,12 +477,12 @@ function level2Setup() {
         9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9
     `);
     scene.setTile(9, projectImages.Stone, true);
-    scene.setTile(6, projectImages.Gate);
-    scene.setTile(7, projectImages.Gate_H)
-    scene.setTile(3, projectImages.Boy);
-    scene.setTile(2, projectImages.Flower);
-    scene.setTile(1, projectImages.Flower_2);
-    scene.setTile(4, projectImages.Flag);
+    scene.setTile(6, projectImages.Gate, false);
+    scene.setTile(7, projectImages.Gate_H, false)
+    scene.setTile(3, projectImages.Boy, false);
+    scene.setTile(2, projectImages.Flower, false);
+    scene.setTile(1, projectImages.Flower_2, false);
+    scene.setTile(4, projectImages.Flag, false);
     boySprite.setPosition(398, 268);
     girlSprite.setPosition(30, 200);
     boss1Sprite.setPosition(130, 292);

--- a/docs/examples/planet-putt-putt.md
+++ b/docs/examples/planet-putt-putt.md
@@ -823,13 +823,13 @@ namespace level {
 
     function setupScene(): void {
         scene.setBackgroundImage(customImages.levelTwo_bg);
-        scene.setTile(1, customArt.stars);
+        scene.setTile(1, customArt.stars, false);
         scene.setTile(2, customArt.ufo, true);
         scene.setTile(3, customArt.black_hole_center, true);
-        scene.setTile(4, customArt.black_hole_up);
-        scene.setTile(5, customArt.black_hole_down);
-        scene.setTile(6, customArt.black_hole_left);
-        scene.setTile(7, customArt.black_hole_right);
+        scene.setTile(4, customArt.black_hole_up, false);
+        scene.setTile(5, customArt.black_hole_down, false);
+        scene.setTile(6, customArt.black_hole_left, false);
+        scene.setTile(7, customArt.black_hole_right, false);
         scene.setTile(8, customArt.floor_inner, true);
         scene.setTile(9, customArt.meteor_front, true);
         scene.setTile(10, customArt.meteor_middle, true);

--- a/docs/examples/treasure-hunt.md
+++ b/docs/examples/treasure-hunt.md
@@ -73,7 +73,7 @@ scene.setTile(0, img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
-`)
+`, false)
 sprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
 . . . b b b b b b b b . . . . . 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -4,32 +4,32 @@
 [
     {
         "name": "Tutorials",
-        "url": "/tutorials",
+        "url": "tutorials",
         "imageUrl": "/static/tutorials/chase-the-pizza.gif"
     },
     {
         "name": "Blocks Games",
-        "url": "/blocks-games",
+        "url": "blocks-games",
         "imageUrl": "/static/examples/duck.png"
     },
     {
         "name": "JavaScript Games",
-        "url": "/javascript-games",
+        "url": "javascript-games",
         "imageUrl": "/static/examples/planet-putt-putt.png"
     },
     {
         "name": "Game Design Concepts",
-        "url": "/concepts",
+        "url": "concepts",
         "imageUrl": "/static/concepts/walking-hero.gif"
     },
     {
         "name": "Lessons",
-        "url": "/lessons",
+        "url": "lessons",
         "imageUrl": "/static/lessons/cherry-pickr.png"
     },
     {
         "name": "Hardware",
-        "url": "/hardware",
+        "url": "hardware",
         "imageUrl": "/static/hardware/ghiarcade.jpg"
     }
 ]
@@ -37,10 +37,10 @@
 
 ## See Also
 
-[Tutorials](/tutorials),
-[Blocks Games](/blocks-games),
-[JavaScript Games](/javascript-games),
-[Game Design Concepts](/concepts),
-[Lessons](/lessons),
-[Hardware](/hardware)
+[Tutorials](tutorials),
+[Blocks Games](blocks-games),
+[JavaScript Games](javascript-games),
+[Game Design Concepts](concepts),
+[Lessons](lessons),
+[Hardware](hardware)
 

--- a/docs/tutorials/simple-maze.md
+++ b/docs/tutorials/simple-maze.md
@@ -153,7 +153,7 @@ a a a a a a a a a a a a a a a a
 a a a a a a a a a a a a a a a a 
 a a a a a a a a a a a a a a a a 
 a a a a a a a a a a a a a a a a 
-`)
+`, false)
 ```
 
 ## Step 5


### PR DESCRIPTION
set tile was changed to make the final param non-optional in blocks, so this adds them in to the examples set tile is used so it doesn't decompile with a hole

<img width="377" alt="screen shot 2019-02-26 at 4 52 14 pm" src="https://user-images.githubusercontent.com/5615930/53457740-44254580-39e8-11e9-9d57-8f3af200da9d.png">

ran checkdocs locally and it passed, this travis build should fail due to the fork issue