### PR TITLE
Fix step 10 of 'Simple Maze' tutorial

### DIFF
--- a/docs/tutorials/simple-maze.md
+++ b/docs/tutorials/simple-maze.md
@@ -356,6 +356,7 @@ game.onUpdate(function () {
 
 Change the ``<`` condition in ``||logic:0 < 0||`` to ``<=``. Find the ``||sprites:mySprite x||`` block and put it in where the first `0` is. Click the dropdown and select ``left``.
 
+```blocks
 let mySprite: Sprite = null
 game.onUpdate(function () {
     if (mySprite.left <= 0) {

--- a/docs/tutorials/simple-maze.md
+++ b/docs/tutorials/simple-maze.md
@@ -354,12 +354,12 @@ game.onUpdate(function () {
 
 ## Step 10
 
-Change the ``<`` condition in ``||logic:0 < 0||`` to ``<=``. Find the ``||sprites:mySprite x||`` block and put it in where the first `0` is. Click the dropdown and select ``left``.
+Find the ``||sprites:mySprite x||`` block and put it in where the first `0` is. Click the dropdown and select ``left``.
 
 ```blocks
 let mySprite: Sprite = null
 game.onUpdate(function () {
-    if (mySprite.left <= 0) {
+    if (mySprite.left < 0) {
     }
 })
 ```
@@ -371,7 +371,7 @@ Put a ``||game:game over||`` inside of ``||logic:if then||``. Click the **(+)** 
 ```blocks
 let mySprite: Sprite = null
 game.onUpdate(function () {
-    if (mySprite.left <= 0) {
+    if (mySprite.left < 0) {
         game.over(true)
     }
 })

--- a/docs/tutorials/simple-maze.md
+++ b/docs/tutorials/simple-maze.md
@@ -354,9 +354,8 @@ game.onUpdate(function () {
 
 ## Step 10
 
-Change the ``<`` condition in ``||logic:0 < 0||`` to ``<=``. Find the ``||sprites:mySprite x||`` block and put it in where the first `0` is. Click the dropdown and select ``left``. Put a ``||game:game over||`` inside of ``||logic:if then||``.
+Change the ``<`` condition in ``||logic:0 < 0||`` to ``<=``. Find the ``||sprites:mySprite x||`` block and put it in where the first `0` is. Click the dropdown and select ``left``.
 
-```blocks
 let mySprite: Sprite = null
 game.onUpdate(function () {
     if (mySprite.left <= 0) {

--- a/docs/tutorials/simple-maze.md
+++ b/docs/tutorials/simple-maze.md
@@ -354,7 +354,19 @@ game.onUpdate(function () {
 
 ## Step 10
 
-Change the ``<`` condition in ``||logic:0 < 0||`` to ``<=``. Find the ``||sprites:mySprite x (horizontal position)||`` block and put it in where the first `0` is. Click the dropdown and select ``left``. Put a ``||game:game over||`` inside of ``||logic:if then||``.
+Change the ``<`` condition in ``||logic:0 < 0||`` to ``<=``. Find the ``||sprites:mySprite x||`` block and put it in where the first `0` is. Click the dropdown and select ``left``. Put a ``||game:game over||`` inside of ``||logic:if then||``.
+
+```blocks
+let mySprite: Sprite = null
+game.onUpdate(function () {
+    if (mySprite.left <= 0) {
+    }
+})
+```
+
+## Step 11
+
+Put a ``||game:game over||`` inside of ``||logic:if then||``. Click the **(+)** symbol and click on the ``LOSE`` button to make it say ``WIN``.
 
 ```blocks
 let mySprite: Sprite = null


### PR DESCRIPTION
Split out step 10 to step 11 for more detail on using gameOver().

Also, why is the effect option rendering on gameOver() when only the win parameter is given (docs only)?

![image](https://user-images.githubusercontent.com/27789908/55269303-e1c19e00-524e-11e9-880d-7fc0d761d63d.png)

Fixes #844 