### PR TITLE
Mention non-default vx and vy in 'Starfield'

### DIFF
--- a/docs/concepts/star-field.md
+++ b/docs/concepts/star-field.md
@@ -18,7 +18,7 @@ game.onUpdate(function () {
 
 ## Step 2
 
-Find ``||sprites:projectile from side||`` in ``||sprites:Sprites||``. Drag it into the ``||game:on game update||``.
+Find ``||sprites:projectile from side||`` in ``||sprites:Sprites||``. Drag it into the ``||game:on game update||``. Change `vx` to `0` and `vy` to `100`. 
 
 ```blocks
 enum SpriteKind {


### PR DESCRIPTION
I put the change in step 2 where the block is first used. How's that?

Fixes #845 

@jwunderl 
