### PR TITLE
discourse social sharing settings

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -292,7 +292,9 @@
         "socialOptions": {
             "twitterHandle": "msmakecode",
             "orgTwitterHandle": "MSMakeCode",
-            "hashtags": "MakeCode"
+            "hashtags": "MakeCode",
+            "discourse": "https://forum.makecode.com/",
+            "discourseCategory": "Arcade"
         },
         "blocklyOptions": {
             "grid": {


### PR DESCRIPTION
Share to forum info. Requires https://github.com/Microsoft/pxt/pull/5453 but harmless without.