### PR TITLE
add slight bounce on top of enemies

### DIFF
--- a/docs/examples/jumpy-platformer.md
+++ b/docs/examples/jumpy-platformer.md
@@ -779,6 +779,7 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Bumper, function (sprite, otherS
     if ((sprite.vy > 0 && !sprite.isHittingTile(CollisionDirection.Bottom)) || sprite.y < otherSprite.top) {
         otherSprite.destroy(effects.ashes, 250);
         otherSprite.vy = -50;
+        sprite.vy = -2 * pixelsToMeters;
         info.changeScoreBy(1);
         music.powerUp.play();
     } else {


### PR DESCRIPTION
Very minor change, but richard pointed out that the player doesn't bounce on the enemy ( / it just continues to fall down), and adding a bounce is very satisfying.

![2019-04-11 15 07 14](https://user-images.githubusercontent.com/5615930/55996278-c782b980-5c6b-11e9-962a-d218dcd4e0c0.gif)
