### PR TITLE
Add button combos extension to approved repos

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -4,7 +4,8 @@
             "Microsoft"
         ],
         "approvedRepos": [
-            "adafruit/Circuit-Playground-Character-Icons"
+            "adafruit/Circuit-Playground-Character-Icons",
+            "jwunderl/pxt-button-combos"
         ]
     },
     "galleries": {


### PR DESCRIPTION
I made this a while back and it can be fairly useful for different types of games (fighting games, dance dance revolution type games, etc)

repo: https://github.com/jwunderl/pxt-button-combos

this one is like a typing game but for button sequences (note that + between two buttons means 'press these at the same time'): https://arcade.makecode.com/34820-28382-49062-64224

![Screen Shot 2019-05-17 at 9 52 12 AM](https://user-images.githubusercontent.com/5615930/57943677-7d53b000-7889-11e9-9d4f-1db1cdf3d847.png) (updated with @ganicke's suggested description)

More thorough explanation on forum: https://forum.makecode.com/t/combo-attack-and-button-combination-extension/169

One thing I was thinking about was how to make the combos easier to visualize in blocks / not just a string of text. I could add an enum of the different buttons and a block to get the button for that, but that's a bit clunky as the blocks would still have to be ``join``ed. Seems like it would need it's own field editor to make it simple, which seems like a bit too much for a simple utility extension