### PR TITLE
fix user enums upgrade (SpriteKind -> SpriteKind.Legacy)

### DIFF
--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -169,6 +169,15 @@ namespace pxt.editor {
                 }
             });
         }
+
+        /**
+         * Upgrade for enum SpriteKind -> SpriteKindLegacy
+         */
+        if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "0.11.20") < 0) {
+            pxt.U.toArray(dom.querySelectorAll("variable[type=SpriteKind]")).forEach(block => {
+                block.setAttribute("type", "SpriteKindLegacy")
+            });
+        }
     }
 
     function changeVariableToSpriteReporter(varBlockOrShadow: Element, reporterName: string) {

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -110,6 +110,14 @@
                         "keysdy": "keydy"
                     }
                 }
+            ],
+            "0.0.0 - 0.11.20": [
+                {
+                    "type": "api",
+                    "map": {
+                        "SpriteKind": "SpriteKindLegacy"
+                    }
+                }
             ]
         }
     },


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1009

Patch old enum SpriteKind to SpriteKindLegacy 