### PR TITLE
hide power blocks

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -242,7 +242,8 @@
             "pins",
             "control",
             "input",
-            "serial"
+            "serial",
+            "power"
         ]
     },
     "simulator": {


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-arcade/issues/1063