### PR TITLE
enum->namespace for sprite kinds

### DIFF
--- a/libs/corgio/corgio.ts
+++ b/libs/corgio/corgio.ts
@@ -225,7 +225,7 @@ namespace corgio {
      * @param x optional initial x position, eg: 10
      * @param y optional initial y position, eg: 70
      */
-    //% blockId=corgiCreate block="corgi of kind %kind=spritetype || at x %x y %y"
+    //% blockId=corgiCreate block="corgi of kind %kind=spritekind || at x %x y %y"
     //% expandableArgumentMode=toggle
     //% inlineInputMode=inline
     //% blockSetVariable=myCorg

--- a/libs/darts/darts.ts
+++ b/libs/darts/darts.ts
@@ -11,7 +11,7 @@ namespace darts {
      * @param x optional initial x position, eg: 10
      * @param y optional initial y position, eg: 110
      */
-    //% blockId=dartsCreate block="dart %img=screen_image_picker of kind %kind=spritetype || at x %x y %y"
+    //% blockId=dartsCreate block="dart %img=screen_image_picker of kind %kind=spritekind || at x %x y %y"
     //% expandableArgumentMode=toggle
     //% inlineInputMode=inline
     //% blockSetVariable=myDart


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1102

Use the new namespace kinds instead of the old enum kinds, which works https://makecode.com/_EUXXaDYd3W2E

