### PR TITLE
Bump codal-samd to 0.2.2 to fix accel freeze

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -158,6 +158,7 @@
                 "openocdScript": "source [find interface/cmsis-dap.cfg]; set CHIPNAME at91samd51g19; source [find target/at91samdXX.cfg]",
                 "openocdScriptAlt": "source [find interface/stlink-v2.cfg]; set CPUTAPID 0x2ba01477; set CHIPNAME at91samd51g19; source [find target/at91samdXX.cfg]",
                 "ramSize": 196608,
+                "flashEnd": 524288,
                 "uf2Family": "0x55114460",
                 "vtableShift": 4
             },
@@ -165,7 +166,7 @@
                 "codalTarget": {
                     "name": "codal-itsybitsy-m4",
                     "url": "https://github.com/lancaster-university/codal-itsybitsy-m4",
-                    "branch": "v0.1.0",
+                    "branch": "v0.2.2",
                     "type": "git"
                 },
                 "codalBinary": "ITSYBITSY_M4",


### PR DESCRIPTION
This merges @jamesadevine merge-i2c_hack branch on the codal side, which should hopefully fix freezes/almost-freezes when using accelerometer on SAMD51

Also, it places 512k limit on games for SAMD, so we get an error when they get too big.

CC @gitri-ms
