### PR TITLE
Repair direct tutorial linkouts

### DIFF
--- a/docs/concepts/bouncing-burger.md
+++ b/docs/concepts/bouncing-burger.md
@@ -1,6 +1,6 @@
 # Bouncing Burger
 
-[Open this tutorial in the editor!](/#tutorial:concepts/bouncing-burger)
+[Open this tutorial in the editor!](/#tutorial:/concepts/bouncing-burger)
 
 ## Introduction @unplugged
 

--- a/docs/concepts/picnic-food.md
+++ b/docs/concepts/picnic-food.md
@@ -1,6 +1,6 @@
 # Picnic Food
 
-[Open this tutorial in the editor!](/#tutorial:concepts/picnic-food)
+[Open this tutorial in the editor!](/#tutorial:/concepts/picnic-food)
 
 ## Introduction @unplugged
 

--- a/docs/concepts/princess-pizza.md
+++ b/docs/concepts/princess-pizza.md
@@ -1,6 +1,6 @@
 # Princess Pizza
 
-[Open this tutorial in the editor!](/#tutorial:concepts/princess-pizza)
+[Open this tutorial in the editor!](/#tutorial:/concepts/princess-pizza)
 
 ## Introduction @unplugged
 

--- a/docs/concepts/setting-the-scene.md
+++ b/docs/concepts/setting-the-scene.md
@@ -1,6 +1,6 @@
 # Setting the Scene
 
-[Open this tutorial in the editor!](/#tutorial:concepts/setting-the-scene)
+[Open this tutorial in the editor!](/#tutorial:/concepts/setting-the-scene)
 
 ## Introduction @unplugged
 

--- a/docs/concepts/sunday-drive.md
+++ b/docs/concepts/sunday-drive.md
@@ -1,6 +1,6 @@
 # Sunday Drive
 
-[Open this tutorial in the editor!](/#tutorial:concepts/sunday-drive)
+[Open this tutorial in the editor!](/#tutorial:/concepts/sunday-drive)
 
 ## Introduction @unplugged
 

--- a/docs/concepts/throw-a-bone.md
+++ b/docs/concepts/throw-a-bone.md
@@ -1,6 +1,6 @@
 # Throw a Bone
 
-[Open this tutorial in the editor!](/#tutorial:concepts/throw-a-bone)
+[Open this tutorial in the editor!](/#tutorial:/concepts/throw-a-bone)
 
 ## Introduction @unplugged
 

--- a/docs/concepts/walking-hero.md
+++ b/docs/concepts/walking-hero.md
@@ -1,6 +1,6 @@
 # Walking Hero
 
-[Open this tutorial in the editor!](/#tutorial:concepts/walking-hero)
+[Open this tutorial in the editor!](/#tutorial:/concepts/walking-hero)
 
 ## Introduction @unplugged
 

--- a/docs/concepts/which-button.md
+++ b/docs/concepts/which-button.md
@@ -1,6 +1,6 @@
 # Which Button?
 
-[Open this tutorial in the editor!](/#tutorial:concepts/which-button)
+[Open this tutorial in the editor!](/#tutorial:/concepts/which-button)
 
 ## Introduction @unplugged
 

--- a/docs/courses/csintro3/about/start.md
+++ b/docs/courses/csintro3/about/start.md
@@ -21,11 +21,11 @@ and blocks that are unique to game development.
 The following tutorials may also be useful in learning about concepts that
 you might not have seen elsewhere:
 
-* [Eat the Doughnut](/#tutorial:tutorials/eat-the-doughnut)
-* [Simple Maze](/#tutorial:tutorials/simple-maze)
-* [Star Field](/#tutorial:tutorials/star-field)
-* [Happy Flower](/#tutorial:tutorials/happy-flower)
-* [Simple Extensions](/#tutorial:tutorials/simple-extensions)
+* [Eat the Doughnut](/#tutorial:/tutorials/eat-the-doughnut)
+* [Simple Maze](/#tutorial:/tutorials/simple-maze)
+* [Star Field](/#tutorial:/tutorials/star-field)
+* [Happy Flower](/#tutorial:/tutorials/happy-flower)
+* [Simple Extensions](/#tutorial:/tutorials/simple-extensions)
 
 Additionally, you may find it useful to check out the review material
 for the previous courses:

--- a/docs/courses/csintro3/arrays/sprites-problems.md
+++ b/docs/courses/csintro3/arrays/sprites-problems.md
@@ -18,7 +18,7 @@ For example, they could ``||sprites:say||`` "Go team go!".
 ## Problem #2: Stop the Stars
 
 Create a star field like the one from the
-[Star Field](/#tutorial:tutorials/star-field) tutorial.
+[Star Field](/#tutorial:/tutorials/star-field) tutorial.
 
 Add an ``||controller:on any button pressed||`` event that **stops** all the stars
 in their current position, so that the stars that are currently on the screen stay


### PR DESCRIPTION
Missing forward slash in direct tutorial links...

Closes #1115 