### PR TITLE
add pxt-color to approved / preferred repos

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -6,12 +6,14 @@
         "approvedRepos": [
             "adafruit/Circuit-Playground-Character-Icons",
             "adafruit/pxt-seesaw",
-            "jwunderl/pxt-button-combos"
+            "jwunderl/pxt-button-combos",
+            "jwunderl/pxt-color"
         ],
         "preferredRepos": [
             "adafruit/Circuit-Playground-Character-Icons",
             "adafruit/pxt-seesaw",
-            "jwunderl/pxt-button-combos"
+            "jwunderl/pxt-button-combos",
+            "jwunderl/pxt-color"
         ]
     },
     "galleries": {


### PR DESCRIPTION
Adds https://github.com/jwunderl/pxt-color to approved repos

Starting as a draft as I'd love some feedback on the package itself whenever anyone has time, not sure on the wording of the blocks / which api's may be needed or unneeded /  etc.

~I definitely still need to resize all the images for the jres and compress them or actually do something proper for them, as I tried sharing and sometimes it didn't seem to work due to file size from all the quick screenshots for the block icons~ resized all images

https://makecode.com/_C4eVqmcqXDRq

![2019-07-03 09 54 10](https://user-images.githubusercontent.com/5615930/60610531-dd8aac80-9d78-11e9-9674-a72b7b5e3c73.gif)

eventually I'd like to add blocks for defining a color palette as well, but that would need a nice field editor to work at all - something like http://hslpicker.com/#1416a9 or the standard-ish rainbow square + luminosity slider, with the 15 / 16 color icons to swap between while selecting them - which sounds a lot like another variant of the image editor, so I'll wait on that for a bit.

Might think about putting it in common packages eventually, just want to sit on that for a bit (don't have to wait till next release to make anything with it that way, and also just to give it a little bit of time to clean it up before merging)