### PR TITLE
Fixed Link to BrainPad website

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -10,7 +10,7 @@ These boards run MakeCode Arcade games. Choose a board to find out more about it
         "name": "BrainPad Arcade",
         "description": "Learn how BrainPad Arcade lets you run games on a small handheld console.",
         "imageUrl": "/static/hardware/ghiarcade.jpg",
-        "url": "https://brainpad.com/arcade",
+        "url": "https://brainpad.com",
         "variant": "hw---stm32f401"
     },
     {


### PR DESCRIPTION
We've changed the website and need to change the link.