### PR TITLE
clean up catch game example

### DIFF
--- a/docs/blocks-games/catch.md
+++ b/docs/blocks-games/catch.md
@@ -1,13 +1,9 @@
 # Catch
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Projectile,
-    Food,
-    Enemy,
-    Projectile2,
-    snake
+namespace SpriteKind {
+    export const Projectile2 = SpriteKind.create()
+    export const snake = SpriteKind.create()
 }
 let sprite_list: Sprite[] = []
 let limit = 0
@@ -15,9 +11,6 @@ let basket: Sprite = null
 let mySprite4: Sprite = null
 let falling: Sprite = null
 let s4Dir = 0
-scene.onHitTile(SpriteKind.Projectile, 5, function (sprite) {
-    sprite.vx = -1 * sprite.vx
-})
 scene.onHitTile(SpriteKind.Projectile, 6, function (sprite) {
     info.changeLifeBy(-1)
     sprite.destroy()
@@ -28,30 +21,20 @@ sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Player, function (sprite, ot
 })
 sprites.onOverlap(SpriteKind.Projectile2, SpriteKind.Player, function (sprite, otherSprite) {
     falling = sprites.create(img`
-        . . . . . . . . . . . . . . . .
-        . . . . . . . . . . . . . . . .
-        . . . . . . 2 2 2 2 . . . . . .
-        . . . . . 2 2 2 2 2 2 . . . . .
-        . . . . 2 2 2 2 2 2 2 2 . . . .
-        . . . . 2 2 2 2 2 2 2 2 . . . .
-        . . . . 2 2 2 2 2 2 2 2 . . . .
-        . . . . 2 2 2 2 2 2 2 2 . . . .
-        . . . . . 2 2 2 2 2 2 . . . . .
-        . . . . . . 2 2 2 2 . . . . . .
-        . . . . . . . . . . . . . . . .
-        . . . . . . . . . . . . . . . .
-        . . . . . . . . . . . . . . . .
-        . . . . . . . . . . . . . . . .
-        . . . . . . . . . . . . . . . .
-        . . . . . . . . . . . . . . . .
+        . . 2 2 2 2 . .
+        . 2 2 2 2 2 2 .
+        2 2 2 2 2 2 2 2
+        2 2 2 2 2 2 2 2
+        2 2 2 2 2 2 2 2
+        2 2 2 2 2 2 2 2
+        . 2 2 2 2 2 2 .
+        . . 2 2 2 2 . .
     `, SpriteKind.Projectile)
+    falling.setFlag(SpriteFlag.BounceOnWall, true)
     falling.setPosition(sprite.x, sprite.y - 5)
     falling.setVelocity(sprite.vx, 0 - sprite.vy)
     falling.ay = sprite.ay
     sprite.destroy()
-})
-scene.onHitTile(SpriteKind.Projectile2, 5, function (sprite) {
-    sprite.vx = -1 * sprite.vx
 })
 scene.onHitTile(SpriteKind.Projectile2, 6, function (sprite) {
     info.changeLifeBy(-1)
@@ -149,47 +132,32 @@ scene.setTileMap(img`
 game.onUpdateInterval(2000, function () {
     if (info.score() < 10 || Math.randomRange(1, Math.min(50, info.score())) < 10) {
         falling = sprites.create(img`
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . 2 2 2 2 . . . . . .
-            . . . . . 2 2 2 2 2 2 . . . . .
-            . . . . 2 2 2 2 2 2 2 2 . . . .
-            . . . . 2 2 2 2 2 2 2 2 . . . .
-            . . . . 2 2 2 2 2 2 2 2 . . . .
-            . . . . 2 2 2 2 2 2 2 2 . . . .
-            . . . . . 2 2 2 2 2 2 . . . . .
-            . . . . . . 2 2 2 2 . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
+            . . 2 2 2 2 . .
+            . 2 2 2 2 2 2 .
+            2 2 2 2 2 2 2 2
+            2 2 2 2 2 2 2 2
+            2 2 2 2 2 2 2 2
+            2 2 2 2 2 2 2 2
+            . 2 2 2 2 2 2 .
+            . . 2 2 2 2 . .
         `, SpriteKind.Projectile)
     } else {
         falling = sprites.create(img`
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . 8 8 8 8 . . . . . . .
-            . . . . 8 8 8 8 8 8 . . . . . .
-            . . . 8 8 8 8 8 8 8 8 . . . . .
-            . . . 8 8 8 8 8 8 8 8 . . . . .
-            . . . 8 8 8 8 8 8 8 8 . . . . .
-            . . . 8 8 8 8 8 8 8 8 . . . . .
-            . . . . 8 8 8 8 8 8 . . . . . .
-            . . . . . 8 8 8 8 . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
-            . . . . . . . . . . . . . . . .
+            . . 8 8 8 8 . .
+            . 8 8 8 8 8 8 .
+            8 8 8 8 8 8 8 8
+            8 8 8 8 8 8 8 8
+            8 8 8 8 8 8 8 8
+            8 8 8 8 8 8 8 8
+            . 8 8 8 8 8 8 .
+            . . 8 8 8 8 . .
         `, SpriteKind.Projectile2)
     }
     falling.setPosition(Math.randomRange(20, 140), 20)
     limit = Math.min(10, info.score())
     falling.setVelocity(Math.randomRange(-100, 100), Math.randomRange(0 - limit, 5))
     falling.ay = 20
+    falling.setFlag(SpriteFlag.BounceOnWall, true)
 })
 game.onUpdateInterval(2200, function () {
     mySprite4.vx = 10 * s4Dir

--- a/docs/blocks-games/catch.md
+++ b/docs/blocks-games/catch.md
@@ -5,19 +5,17 @@ namespace SpriteKind {
     export const Projectile2 = SpriteKind.create()
     export const snake = SpriteKind.create()
 }
-let sprite_list: Sprite[] = []
-let limit = 0
-let basket: Sprite = null
-let mySprite4: Sprite = null
-let falling: Sprite = null
-let s4Dir = 0
 scene.onHitTile(SpriteKind.Projectile, 6, function (sprite) {
     info.changeLifeBy(-1)
     sprite.destroy()
 })
 sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Player, function (sprite, otherSprite) {
-    sprite.destroy()
     info.setScore(info.score() + 1)
+    sprite.destroy()
+})
+scene.onHitTile(SpriteKind.Projectile2, 6, function (sprite) {
+    info.changeLifeBy(-1)
+    sprite.destroy()
 })
 sprites.onOverlap(SpriteKind.Projectile2, SpriteKind.Player, function (sprite, otherSprite) {
     falling = sprites.create(img`
@@ -36,13 +34,11 @@ sprites.onOverlap(SpriteKind.Projectile2, SpriteKind.Player, function (sprite, o
     falling.ay = sprite.ay
     sprite.destroy()
 })
-scene.onHitTile(SpriteKind.Projectile2, 6, function (sprite) {
-    info.changeLifeBy(-1)
-    sprite.destroy()
-})
-s4Dir = 1
+let limit = 0
+let falling: Sprite = null
+let s4Dir = 1
 info.setLife(3)
-basket = sprites.create(img`
+let basket = sprites.create(img`
     . . . . . . . . . . . . . . . .
     . . . . . . . . . . . . . . . .
     . . . . . . . . . . . . . . . .
@@ -62,8 +58,7 @@ basket = sprites.create(img`
 `, SpriteKind.Player)
 basket.setPosition(80, 100)
 controller.moveSprite(basket, 160, 0)
-sprite_list = sprites.allOfKind(SpriteKind.Projectile)
-mySprite4 = sprites.create(img`
+let mySprite4 = sprites.create(img`
     . . . . . . . . . . . . . . . .
     . 8 8 8 8 8 8 8 1 1 1 1 1 . . .
     8 8 8 8 8 8 8 8 1 1 1 1 1 1 . .


### PR DESCRIPTION
clean up the catch game, as it had a few unused things / old sprite kinds / sprites that were bigger than necessary. Also makes it use the ``bounce on walls`` flag to simplify the code (and fix the issue here)

https://makecode.com/_JxrC7L8vmK6x

This game was relying on the speed staying the same and the tile map just stopping the sprite to work, which is pretty wonky behavior that doesn't work properly with acceleration (e.g. when I get out of bed I don't hit the ground at terminal velocity from gravity pulling me down all night, and a platformer character shouldn't fall into a hole at 500 pixels per second just because the player didn't jump)

re https://github.com/microsoft/pxt-arcade/issues/1143, but somewhat tangential; this fixes the game itself but I can make it so the current version works as well pretty easily by just running the collision event before updating the speed and then changing the speed according to tmap rules only if the collision event didn't change the speed - basically make the collision event give the player a chance to 'override' the standard velocity changes if they choose to