### PR TITLE
renampe npm package from pxt-32 to pxt-arcade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pxt-32",
+  "name": "pxt-arcade",
   "version": "0.13.8",
   "description": "Small arcade editor for MakeCode",
   "keywords": [


### PR DESCRIPTION
Our CLI assumes that the npm package name is ``pxt-${pxtarget id}``. The cloud does not rely on the package.json name entry.