### PR TITLE
add description for arcade homepage

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -3,7 +3,8 @@
     "name": "arcade",
     "nickname": "arcade",
     "thumbnailName": "MakeCode Arcade",
-    "title": "MakeCode Arcade",
+    "title": "Microsoft MakeCode Arcade",
+    "description": "Develop your programming skills by quickly creating and modding retro arcade games with Blocks and JavaScript in the MakeCode editor",
     "corepkg": "core",
     "cloud": {
         "workspace": false,


### PR DESCRIPTION
Currently it's just junk, resulting in useless descriptions on google searches:

![Screen Shot 2019-07-25 at 5 48 10 PM](https://user-images.githubusercontent.com/5615930/61917974-7a69e100-af04-11e9-8d1f-de62ba365f9c.png)
![Screen Shot 2019-07-25 at 5 48 01 PM](https://user-images.githubusercontent.com/5615930/61917975-7a69e100-af04-11e9-9e34-e50e75a01efe.png)


