### PR TITLE
Remove bootloader config overrides for JACDAC on pybadge/gamer

### DIFF
--- a/libs/hw---samd51/config.ts
+++ b/libs/hw---samd51/config.ts
@@ -1,5 +1,3 @@
 namespace config {
     // all from bootloader
-    export const PIN_JACK_TX = DAL.PA04
-    export const PIN_JACK_COMMLED = DAL.PA23
 }


### PR DESCRIPTION
This PR removes config overrides for the JACDAC pin on pybadge and pygamer.

The reason for the original override is that the current hardware layout for PA23 (D13), used for JACDAC communications, has an LED that causes a voltage drop bringing the idle state of the line to ~1.6v:

<img width="502" alt="Screenshot 2019-07-30 at 14 14 47" src="https://user-images.githubusercontent.com/4742697/62138275-4cf3ad80-b2df-11e9-8649-0f66aaac82cf.png">

(top trace shows digital equivalent of bottom analog trace)

As the microcontroller does not register 1.6v as a logical one, it is not a valid idle condition in JACDAC. Instead, we defined PA23 to be used as the COMM_LED for JACDAC, and PA04 (A4) to be used for JACDAC comms as PA04 does not have any additional hardware components that causes a drop in voltage. 
 