### PR TITLE
specialize feather support on arcade

### DIFF
--- a/libs/animation/pxt.json
+++ b/libs/animation/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/animation"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/animation",
+    "weight": 80
 }

--- a/libs/controller/pxt.json
+++ b/libs/controller/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/controller"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/controller",
+    "weight": 99
 }

--- a/libs/corgio/pxt.json
+++ b/libs/corgio/pxt.json
@@ -8,5 +8,6 @@
     "public": true,
     "dependencies": {
         "game": "file:../game"
-    }
+    },
+    "weight": 79
 }

--- a/libs/darts/pxt.json
+++ b/libs/darts/pxt.json
@@ -8,5 +8,6 @@
     "public": true,
     "dependencies": {
         "game": "file:../game"
-    }
+    },
+    "weight": 78
 }

--- a/libs/edge-connector/pxt.json
+++ b/libs/edge-connector/pxt.json
@@ -1,3 +1,6 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/edge-connector"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/edge-connector",
+    "requiredCategories": [
+        "pins"
+    ]
 }

--- a/libs/feather/pxt.json
+++ b/libs/feather/pxt.json
@@ -1,3 +1,6 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/feather"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/feather",
+    "requiredCategories": [
+        "pins"
+    ]
 }

--- a/libs/feather/targetoverrides.d.ts
+++ b/libs/feather/targetoverrides.d.ts
@@ -1,6 +1,6 @@
 declare namespace pins {
-    //% fixedInstance shim=pxt::getPinCfg(CFG_PIN_A8)
-    const A8: AnalogInPin;
-    //% fixedInstance shim=pxt::getPinCfg(CFG_PIN_A9)
-    const A9: AnalogInPin;
+    //% fixedInstance shim=pxt::getPinCfg(CFG_PIN_D2)
+    const D2: PwmPin;
+    //% fixedInstance shim=pxt::getPinCfg(CFG_PIN_D3)
+    const D3: PwmPin;
 }

--- a/libs/feather/targetoverrides.d.ts
+++ b/libs/feather/targetoverrides.d.ts
@@ -1,0 +1,6 @@
+declare namespace pins {
+    //% fixedInstance shim=pxt::getPinCfg(CFG_PIN_A8)
+    const A8: AnalogInPin;
+    //% fixedInstance shim=pxt::getPinCfg(CFG_PIN_A9)
+    const A9: AnalogInPin;
+}

--- a/libs/palette/pxt.json
+++ b/libs/palette/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/palette"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/palette",
+    "weight": 75
 }

--- a/libs/rotary-encoder/pxt.json
+++ b/libs/rotary-encoder/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/rotary-encoder"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/rotary-encoder",
+    "hidden": true
 }

--- a/libs/storyboard/pxt.json
+++ b/libs/storyboard/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/storyboard"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/storyboard",
+    "weight": 81
 }


### PR DESCRIPTION
Expose pins A8, A9 (JST connectors) on py***
Requires https://github.com/microsoft/pxt-common-packages/pull/909
Requires https://github.com/microsoft/pxt-common-packages/pull/912
Requires https://github.com/microsoft/pxt/pull/5783 (will still work without it)