### PR TITLE
remove leading new lines that seem to be breaking translations

### DIFF
--- a/docs/blocks-games/duck.md
+++ b/docs/blocks-games/duck.md
@@ -3,7 +3,6 @@
 Jump to avoid the trees!
 
 ```blocks
-
 enum ActionKind {
     Walking,
     Idle,

--- a/docs/blocks-games/eat-the-fruit.md
+++ b/docs/blocks-games/eat-the-fruit.md
@@ -3,7 +3,6 @@
 Dodge the junk and eat the fruits!
 
 ```blocks
-
 let projectile: Sprite = null
 let mySprite: Sprite = null
 let choice = 0

--- a/docs/blocks-games/level-game.md
+++ b/docs/blocks-games/level-game.md
@@ -3,7 +3,6 @@
 A game with an example of how to do levels and use the timer.
 
 ```blocks
-
 let food: Sprite = null
 let player: Sprite = null
 let level = 0

--- a/docs/blocks-games/space-destroyer.md
+++ b/docs/blocks-games/space-destroyer.md
@@ -3,7 +3,6 @@
 An example program that uses blocks and built-in images.
 
 ```blocks
-
 let asteroids: Image[] = []
 let ship: Sprite = null
 let projectile: Sprite = null

--- a/docs/concepts/bouncing-burger.md
+++ b/docs/concepts/bouncing-burger.md
@@ -11,8 +11,6 @@
 Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into the ``||loops:on start||``.
 
 ```blocks
-
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
@@ -40,8 +38,6 @@ Click on the grey box in ``||variables:set mySprite to||`` to open the image edi
 This will set the image of the ``||sprites:Sprite||`` to a burger; run the code and make sure you see it on the screen!
 
 ```blocks
-
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . c c c c c 6 6 6 6 6 . . . . . . . . . . . 
@@ -86,8 +82,6 @@ Find ``||sprites:set mySprite x to 0||`` in ``||sprites:Sprites||``. Place it af
 This will make the sprite move to the **right** across the screen, because the ``||sprites:x||`` position will be **increasing**.
 
 ```blocks
-
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . c c c c c 6 6 6 6 6 . . . . . . . . . . . 
@@ -133,8 +127,6 @@ Find ``||sprites:set mySprite x to 0||`` in ``||sprites:Sprites||``. Place it af
 This will make the sprite move **downwards** across the screen, because the ``||sprites:y||`` position will be **increasing**.
 
 ```blocks
-
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . c c c c c 6 6 6 6 6 . . . . . . . . . . . 
@@ -179,8 +171,6 @@ mySprite.vy = 60
 Find ``||sprites:set mySprite stay in screen||`` in ``||sprites:Sprites||``. Place it after ``||variables:set mySprite to||``.
 
 ```blocks
-
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . c c c c c 6 6 6 6 6 . . . . . . . . . . . 
@@ -229,8 +219,6 @@ Change ``||sprites:stay in screen||`` to ``||sprites:bounce on wall||``, and cli
 This will make it so that when the burger its a wall, it will 'bounce' off the wall, changing the ``||sprites:vx||`` or ``||sprites:vy||``
 
 ```blocks
-
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . c c c c c 6 6 6 6 6 . . . . . . . . . . . 

--- a/docs/concepts/picnic-food.md
+++ b/docs/concepts/picnic-food.md
@@ -15,7 +15,6 @@ A ``||sprites:y||`` position of 0 will place the sprite at the **top** of the sc
 Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into the ``||loops:on start||``. Click on ``||variables:mySprite||``, select ``rename variable...``, and change the name from ``||variables:mySprite||`` to ``||variables:cherry||``.
 
 ```blocks
-
 let cherry = sprites.create(img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
@@ -41,7 +40,6 @@ let cherry = sprites.create(img`
 Open the image editor for ``||variables:cherry||``. You can either draw your own image of a cherry, or open the Gallery and find a premade picture in there.
 
 ```blocks
-
 let cherry: Sprite = null
 cherry = sprites.create(img`
 . . . . . . . . . . . 6 6 6 6 6 
@@ -70,7 +68,6 @@ Find ``||sprites:set mySprite position to x 0 y 0||`` in ``||sprites:Sprites||``
 This will place the ``||variables:cherry||`` at the top of the screen, a little bit away (25 pixels) from the left side.
 
 ```blocks
-
 let cherry: Sprite = null
 cherry = sprites.create(img`
 . . . . . . . . . . . 6 6 6 6 6 
@@ -100,7 +97,6 @@ In ``||sprites:set mySprite position to x 0 y 0||``, change ``||sprites:y||`` to
 This will move the sprite **down** the screen by 45 pixels.
 
 ```blocks
-
 let cherry: Sprite = null
 cherry = sprites.create(img`
 . . . . . . . . . . . 6 6 6 6 6 
@@ -128,7 +124,6 @@ cherry.setPosition(25, 45)
 Create another ``||sprites:Sprite||``, and rename it ``||variables:chicken||``. Find (or create) an image of chicken to represent it.
 
 ```blocks
-
 let chicken: Sprite = null
 let cherry: Sprite = null
 cherry = sprites.create(img`
@@ -175,7 +170,6 @@ chicken = sprites.create(img`
 Set the ``||variables:chicken||``'s ``||sprites:x||`` position 120, and it's ``||sprites:y||`` position to 80.
 
 ```blocks
-
 let chicken: Sprite = null
 let cherry: Sprite = null
 cherry = sprites.create(img`

--- a/docs/concepts/princess-pizza.md
+++ b/docs/concepts/princess-pizza.md
@@ -11,7 +11,6 @@
 Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into the ``||loops:on start||``. Click on ``||variables:mySprite||``, select ``rename variable...``, and change the name from ``||variables:mySprite||`` to ``||variables:princess||``.
 
 ```blocks
-
 let princess = sprites.create(img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
@@ -37,7 +36,6 @@ let princess = sprites.create(img`
 Open the image editor for ``||variables:princess||``, and select or create an image of a princess.
 
 ```blocks
-
 let princess: Sprite = null
 princess = sprites.create(img`
 . . . . . f f 4 4 f f . . . . . 
@@ -64,7 +62,6 @@ f b b f f f e e e e f f f b b f
 Find ``||controller:move mySprite with buttons||`` in ``||controller:Controller||``. Place it after ``||variables:set princess to||``. Change ``||variables:mySprite||`` to ``||variables:princess||``.
 
 ```blocks
-
 let princess: Sprite = null
 princess = sprites.create(img`
 . . . . . f f 4 4 f f . . . . . 
@@ -92,7 +89,6 @@ controller.moveSprite(princess)
 Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into the ``||loops:on start||``. Rename ``||variables:mySprite||`` to ``||variables:pizza||``. Open the image editor, and select or create an image of a pizza.
 
 ```blocks
-
 let pizza: Sprite = null
 let princess: Sprite = null
 princess = sprites.create(img`
@@ -139,7 +135,6 @@ b 5 5 5 5 d d 4 4 4 4 . . . . .
 Find ``||sprites:set mySprite position to x 0 y 0||`` in ``||sprites:Sprites||``. Change ``||variables:mySprite||`` to ``||variables:pizza||``, ``||sprites:x||`` to 140, and ``||sprites:y||`` to 100.
 
 ```blocks
-
 let pizza: Sprite = null
 let princess: Sprite = null
 princess = sprites.create(img`
@@ -189,7 +184,6 @@ In the ``||variables:pizza||`` ``||sprites:Sprite||``, select ``||sprites:kind P
 A ``||sprites:Sprite|``'s ``||sprites:Kind||`` is used to identify what type of sprite it is; this helps to group different sprites together.
 
 ```blocks
-
 let pizza: Sprite = null
 let princess: Sprite = null
 princess = sprites.create(img`
@@ -239,7 +233,6 @@ Find ``||sprites:on sprite of kind Player overlaps otherSprite of kind Player||`
 This event will occur whenever two ``||sprites:Sprites||`` of the given ``||sprites:kinds||`` are on top of eachother.
 
 ```blocks
-
 let pizza: Sprite = null
 let princess: Sprite = null
 sprites.onOverlap(SpriteKind.Food, SpriteKind.Player, function (sprite, otherSprite) {
@@ -292,7 +285,6 @@ Find ``||game:game over||`` in ``||game:Game||``, and drag it into the ``||sprit
 This will cause the game to end when the ``||sprites:princess||`` touches the ``||sprites:pizza||``.
 
 ```blocks
-
 let pizza: Sprite = null
 let princess: Sprite = null
 sprites.onOverlap(SpriteKind.Food, SpriteKind.Player, function (sprite, otherSprite) {

--- a/docs/concepts/setting-the-scene.md
+++ b/docs/concepts/setting-the-scene.md
@@ -121,7 +121,6 @@ scene.setTile(5, img`
 Find ``||variables:set mySprite to||`` and drag it into ``||loops:on start||`` to create a ``||sprites:Sprite||``. Open the image editor for the ``||sprites:Sprite||`` and create an image to represent it on the screen.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setTileMap(img`
 . . . . . . . . . . 
@@ -178,7 +177,6 @@ Find ``||controller:move mySprite with buttons||`` and drag it into ``||loops:on
 This will let the player move the character around the map that is displayed on the screen. However, there is one issue; the player can move straight through the beautiful tiles we designed! This can be fixed by changing the tile to be a ``||scene:Wall||``.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setTileMap(img`
 . . . . . . . . . . 
@@ -236,7 +234,6 @@ In the ``||scene:set tile to with wall||`` click on ``||scene:off||`` to turn it
 This will set the tile you created to be a ``||scene:Wall||``, so that the player cannot move through it.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setTileMap(img`
 . . . . . . . . . . 

--- a/docs/concepts/star-field.md
+++ b/docs/concepts/star-field.md
@@ -21,7 +21,6 @@ game.onUpdate(function () {
 Find ``||sprites:projectile from side||`` in ``||sprites:Sprites||``. Drag it into the ``||game:on game update||``. Change `vx` to `0` and `vy` to `100`. 
 
 ```blocks
-
 game.onUpdate(function () {
     let projectile = sprites.createProjectileFromSide(img`
 . . . . . . . . . . . . . . . . 
@@ -51,7 +50,6 @@ Click on the grey box in ``||variables:set projectile to||`` and create a single
 ![Creating star image](/static/concepts/star-field/creating-star-image.gif)
 
 ```blocks
-
 game.onUpdate(function () {
     let projectile = sprites.createProjectileFromSide(img`
 . . . . . . . . . . . . . . . . 
@@ -79,7 +77,6 @@ game.onUpdate(function () {
 Find ``||Math:pick random 0 to 10||`` in ``||Math:Math||``. Change the ``0`` to ``20``, and the ``10`` to ``30``. Place it in ``||sprites:vy||`` in ``||sprites:projectile||``.
 
 ```blocks
-
 game.onUpdate(function () {
     let projectile = sprites.createProjectileFromSide(img`
 . . . . . . . . . . . . . . . . 
@@ -107,7 +104,6 @@ game.onUpdate(function () {
 Find ``||sprites:set mySprite position to||`` in ``||sprites:Sprites||``. Place it after ``||variables:set projectile to||`` and change ``||variables:mySprite||`` to ``||variables:projectile||``.
 
 ```blocks
-
 game.onUpdate(function () {
     let projectile = sprites.createProjectileFromSide(img`
 . . . . . . . . . . . . . . . . 
@@ -136,7 +132,6 @@ game.onUpdate(function () {
 Grab another ``||Math:pick random 0 to 10||`` and put it in as the ``||sprites:x||`` value for position. Find ``||scene:screen width||`` in ``||scene:Scene||``, and replace the ``10`` with it.
 
 ```blocks
-
 game.onUpdate(function () {
     let projectile = sprites.createProjectileFromSide(img`
 . . . . . . . . . . . . . . . . 
@@ -167,7 +162,6 @@ At this point, too many stars are being created. This is fixed by surrounding th
 ![Surround with if then](/static/concepts/star-field/surround-if-then.gif)
 
 ```blocks
-
 game.onUpdate(function () {
     if (true) {
         let projectile = sprites.createProjectileFromSide(img`
@@ -198,7 +192,6 @@ game.onUpdate(function () {
 Get a ``||Math:0 % chance||`` block and replace the ``true`` condition in the ``||logic: if then||`` with it. Change the ``0`` to ``25``.
  
 ```blocks
-
 game.onUpdate(function () {
     if (Math.percentChance(25)) {
         let projectile = sprites.createProjectileFromSide(img`
@@ -237,7 +230,6 @@ Find ``||sprites:set mySprite stay in screen||`` in ``||sprites:Sprites||``. Pla
 This will also have a large effect on the frame rate, as the game can ignore the fact that the stars overlap with the other sprites in the game.
 
 ```blocks
-
 game.onUpdate(function () {
     if (Math.percentChance(25)) {
         let projectile = sprites.createProjectileFromSide(img`

--- a/docs/concepts/sunday-drive.md
+++ b/docs/concepts/sunday-drive.md
@@ -31,7 +31,6 @@ game.onUpdateInterval(1000, function () {
 Find ``||sprites:projectile from side||`` in ``||sprites:Sprites||``, and drag it into the ``||loops:on game update interval||``. Open the image editor for ``||variables:projectile||``, and select or create an image of a car that is facing **right**.
 
 ```blocks
-
 let projectile: Sprite = null;
 game.onUpdateInterval(1000, function () {
     projectile = sprites.createProjectileFromSide(img`
@@ -60,7 +59,6 @@ game.onUpdateInterval(1000, function () {
 In the ``||sprites:projectile||``, set the ``||sprites:vx||`` to 40, so that it drives across the screen.
 
 ```blocks
-
 let projectile: Sprite = null;
 game.onUpdateInterval(1000, function () {
     projectile = sprites.createProjectileFromSide(img`
@@ -89,7 +87,6 @@ game.onUpdateInterval(1000, function () {
 In the ``||sprites:projectile||``, set the ``||sprites:vy||`` to 0, so that the cars drive **only** to the right.
 
 ```blocks
-
 let projectile: Sprite = null;
 game.onUpdateInterval(1000, function () {
     projectile = sprites.createProjectileFromSide(img`
@@ -118,7 +115,6 @@ game.onUpdateInterval(1000, function () {
 Find ``||sprites:set mySprite x to 0||`` from ``||sprites:Sprites||``, and drag it after the ``||variables:set projectile to||``. Change ``||variables:mySprite||`` to ``||variables:projectile||``, and change ``||sprites:x||`` to ``||sprites:y||``.
 
 ```blocks
-
 let projectile: Sprite = null;
 game.onUpdateInterval(1000, function () {
     projectile = sprites.createProjectileFromSide(img`
@@ -150,7 +146,6 @@ Find ``||math:pick random 0 to 10||`` in ``||math:Math||``, and replace the 0 in
 This will place the ``||variables:projectile||`` in a random ``||sprites:y||`` position between 0 and 10.
 
 ```blocks
-
 let projectile: Sprite = null;
 game.onUpdateInterval(1000, function () {
     projectile = sprites.createProjectileFromSide(img`
@@ -182,7 +177,6 @@ Find ``||scene:screen height||`` in ``||scene:Scene||``. Replace the 10 in ``||m
 ``||scene:screen height||`` is the height of the screen (120), so this will place the ``||variables:projectile||`` in a random position on the left side of the screen.
 
 ```blocks
-
 let projectile: Sprite = null;
 game.onUpdateInterval(1000, function () {
     projectile = sprites.createProjectileFromSide(img`

--- a/docs/concepts/throw-a-bone.md
+++ b/docs/concepts/throw-a-bone.md
@@ -13,7 +13,6 @@ This allows you to easily create things like asteroids that move across the scre
 Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``, and drag it into the ``||loops:on start||``. Open the image editor for ``||variables:mySprite||``, and select or create an image of a skeleton.
 
 ```blocks
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . . . . . . . . . .
@@ -49,7 +48,6 @@ Find ``||sprites:projectile from mySprite||`` in ``||sprites:Sprites||``, and dr
 This will create a ``||sprites:Sprite||`` that starts in the same location as ``||sprites:mySprite||``, no matter where it is on the screen.
 
 ```blocks
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . . . . . . . . . .
@@ -101,7 +99,6 @@ let projectile = sprites.createProjectileFromSprite(img`
 Open the image editor for ``||variables:projectile||``, and draw an image of a bone.
 
 ```blocks
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . . . . . . . . . .
@@ -153,7 +150,6 @@ let projectile = sprites.createProjectileFromSprite(img`
 In ``||sprites:projectile||``, change ``||sprites:vy||`` from 100 to -15, so that it moves **upwards** instead of **downwards**.
 
 ```blocks
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . . . . . . . . . .
@@ -205,7 +201,6 @@ let projectile = sprites.createProjectileFromSprite(img`
 In ``||sprites:projectile||``, set ``||sprites:vx||`` to 50. Run the game, and notice that the ``||variables:projectile||`` now moves to the **right** as well.
 
 ```blocks
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . . . . . . . . . .
@@ -259,7 +254,6 @@ Find ``||controller:on A button pressed||`` in ``||controller:Controller||``, an
 This will create an event that occurs whenever the person playing the game presses the ``||controller:A||`` button. Whenever that event occurs, ``||variables:mySprite||`` will 'throw' a new bone up and to the right.
 
 ```blocks
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . . . . . . . . . .

--- a/docs/concepts/walking-hero.md
+++ b/docs/concepts/walking-hero.md
@@ -15,8 +15,6 @@ Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into 
 This ``||sprites:Sprite||`` will represent the main character in the game; for now, it has no image and doesn't do anything, though.
 
 ```blocks
-
-
 let mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
@@ -44,8 +42,6 @@ Click on the grey box in ``||variables:set mySprite to||`` to open the image edi
 When you close the image editor by clicking outside of it, the image you drew will show up in the center of the screen in the simulator.
 
 ```blocks
-
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . 7 7 . . . . . . 
@@ -74,7 +70,6 @@ This ``||sprites:Sprite||`` represents the main character in our game, so it sho
 Find ``||controller:move mySprite with buttons||`` in ``||controller:Controller||``. Place it after ``||variables:set mySprite to||``.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . 7 7 . . . . . . 

--- a/docs/courses/csintro1/intro/info.md
+++ b/docs/courses/csintro1/intro/info.md
@@ -99,7 +99,6 @@ When a nurse needs to take a patient's heart rate with their other vital signs, 
 7. **Challenge:** instead of outputting an exact estimate, give a range that the button presses will likely fall into - estimate this by making the low end of the range correspond to `(score - 1) * 10`, and the high end of the range correspond to `(score + 1) * 10`. For example, if the score were 5, the output should be something along the lines of "between 40 and 60"
 
 ```blocks
-
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     info.changeScoreBy(1)
 })
@@ -136,7 +135,6 @@ When doing the challenge, remember to pay careful attention to the order of oper
 To join more than just two strings and numbers, press the **+** to add more locations to combine strings
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro1/intro/sprites.md
+++ b/docs/courses/csintro1/intro/sprites.md
@@ -22,7 +22,6 @@ The blocks needed to create sprites are found in the ``||sprites:Sprites||`` men
 [Empty Sprite Example](https://makecode.com/_g3CcuWigwKR8)
 
 ```blocks
-
 let mySprite: Sprite = null
 
 mySprite = sprites.create(img`
@@ -54,7 +53,6 @@ Look at the blocks, and note that a name for the sprite (``||variables:mySprite|
 [Hot Sauce Example Sprite](https://makecode.com/_VEXXpq9RtRfT)
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro1/loops/increment-loop.md
+++ b/docs/courses/csintro1/loops/increment-loop.md
@@ -72,7 +72,6 @@ info.startCountdown(5)
 A spiral increases the length of each side. In the example below the sides are 5, 6, 7 and 8 pixels long. To continue the spiral we will need to continue to make each side longer than the last. Notice that some of the lengths are negative values (these are in order to move up or move left).
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . 8 . . . . . . . 
@@ -144,7 +143,6 @@ In the following task we will need to update all sides of the spiral.
 The ``||loops:for||`` loop is another common loop. This loop has a counter variable built in that has the default name ``||variables:index||`` in blocks. The value of ``||variables:index||`` is incremented between the values entered in the ``||loops:for||`` loop. We can use the ``||variables:index||`` variable inside of the body of the ``||loops:for||`` loop.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro1/loops/intro.md
+++ b/docs/courses/csintro1/loops/intro.md
@@ -39,7 +39,6 @@ Start off by trying to solve a small task: slowly move a ghost from the center o
 3. Review the blocks that caused this to happen. What would you need to add if the screen was twice as large as it is?
 
 ```blocks
-
 let sprite: Sprite = null
 sprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -149,7 +148,6 @@ Motion and flips will both occur very quickly unless you include the ``||loops:p
 ### ~
 
 ```blocks
-
 let boomerang: Sprite = null
 boomerang = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro1/loops/physics.md
+++ b/docs/courses/csintro1/loops/physics.md
@@ -31,7 +31,6 @@ A sprite's ``||sprites:vy||``, represents the sprite's velocity in the vertical 
 3. Notice how the behavior for the two sprites is similar, and how it is different
 
 ```blocks
-
 let second: Sprite = null
 let first: Sprite = null
 first = sprites.create(img`
@@ -112,7 +111,6 @@ In @boardname@, a sprite's acceleration is defined in terms of **pixels per seco
 Below is a sprite with an acceleration applied. We set the sprite position to the bottom of the screen every 2 seconds in order to see how the velocity changes over time. We see the sprite has a greater velocity with each pass.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -147,7 +145,6 @@ mySprite.destroy()
 3. Notice how the behavior for the two sprites is similar, and how it is different
 
 ```blocks
-
 let second: Sprite = null
 let first: Sprite = null
 first = sprites.createProjectileFromSide(img`

--- a/docs/courses/csintro1/loops/projectile-from.md
+++ b/docs/courses/csintro1/loops/projectile-from.md
@@ -38,7 +38,6 @@ ball = sprites.createProjectileFromSprite(img`
 3. Save the code for the task (name it "Throw Ball") 
 
 ```blocks
-
 let mySprite: Sprite = null
 let ball: Sprite = null
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
@@ -98,7 +97,6 @@ We can use projectiles to create an animation. The following examples build a pr
 ### Example #2a: Cloud projectile
 
 ```blocks
-
 let cloud: Sprite = null
 cloud = sprites.createProjectileFromSide(img`
 . . . . . . . . . . . . . . . . 
@@ -127,7 +125,6 @@ There's not much to this code; it spawns a cloud, which slowly moves across the 
 Review the code carefully for the use of ``||sprites:ghost on||`` and ``||sprites:projectile from sprite||`` for the raindrop projectiles. 
 
 ```blocks
-
 
 let raindrop: Sprite = null
 let cloud: Sprite = null
@@ -186,7 +183,6 @@ raindrop.x += Math.randomRange(1, 14)
 ```
 
 ```blocks
-
 
 let raindrop: Sprite = null
 let cloud: Sprite = null

--- a/docs/courses/csintro1/loops/projectiles.md
+++ b/docs/courses/csintro1/loops/projectiles.md
@@ -27,7 +27,6 @@ We can use projectiles to create sprites that move across the screen. Let's star
 4. Look for what portion of the blocks makes the bird move across the screen, instead of just staying still
 
 ```blocks
-
 let projectile: Sprite = sprites.createProjectileFromSide(img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
@@ -99,7 +98,6 @@ Notice that the ``||sprites:kind||`` of the ``||sprites:projectile||`` is ``Proj
 
 ```blocks
 
-
 let projectile: Sprite = null
 sprites.onDestroyed(SpriteKind.Projectile, function (sprite) {
     info.changeScoreBy(1)
@@ -139,7 +137,6 @@ Games often create many projectiles, one after another. We can create multiple p
 This example randomly places the projectiles on the screen with a random velocity.
 
 ```blocks
-
 
 let projectile: Sprite = null
 let mySprite: Sprite = null
@@ -202,7 +199,6 @@ We have seen that it is useful for projectiles to come from random positions, bu
 5. Modify the ``||sprites:set projectile y to||`` block to set the projectiles' ``||sprites:y||`` position to the value `10 * index`, so that they start further down the screen on each iteration
 
 ```blocks
-
 let projectile: Sprite = null
 projectile = sprites.createProjectileFromSide(img`
 . 6 . . . . . . . . . . . . . . 
@@ -240,7 +236,6 @@ Projectiles with only a ``||sprites:y||`` velocity will start on the top or bott
 4. Save the code for the task (name it "Top Left")
 
 ```blocks
-
 let projectile: Sprite = null
 projectile = sprites.createProjectileFromSide(img`
 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 

--- a/docs/courses/csintro1/motion/overlap1.md
+++ b/docs/courses/csintro1/motion/overlap1.md
@@ -31,7 +31,6 @@ Sometimes there will be only a single sprite of a given ``||sprites:kind||`` (fo
 [Overlap event](https://makecode.com/_e77ia1MAyA0U)
 
 ```blocks
-
 let head: Sprite = null
 let food: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {
@@ -121,7 +120,6 @@ The ``||sprites:ghost on||`` setting for sprites, when turned on, makes the spri
 [Ghost and Overlap](https://makecode.com/_FR3ciEHqR8YE)
 
 ```blocks
-
 let head: Sprite = null
 let food: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {

--- a/docs/courses/csintro1/motion/random.md
+++ b/docs/courses/csintro1/motion/random.md
@@ -48,7 +48,6 @@ Games often have an element of luck and surprise to keep the player engaged. In 
 4. Examine the use of ``||math:pick random||`` in the sprite location block. The code does not assign the chosen random number to a variable before using it
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro1/motion/sprite-motion-event.md
+++ b/docs/courses/csintro1/motion/sprite-motion-event.md
@@ -26,7 +26,6 @@ In these activities, the student will use:
 3. Save the code for the task (name it "motionLR")
 
 ```blocks
-
 let agent: Sprite = null
 controller.right.onEvent(ControllerButtonEvent.Pressed, function () {
     agent.x += 3
@@ -77,7 +76,6 @@ If we have a positive `X` velocity, for example, then our sprite will continue t
 3. Save the code for the task (name it "velocityLR")
 
 ```blocks
-
 let agent: Sprite = null
 controller.right.onEvent(ControllerButtonEvent.Pressed, function () {
     agent.vx += 1
@@ -128,7 +126,6 @@ We have created motion by capturing the key pad events and incrementing (or decr
 5. Note the blocks in ``||game:on game update||``
 
 ```blocks
-
 let ball: Sprite = null
 scene.setBackgroundColor(1)
 ball = sprites.create(img`
@@ -186,7 +183,6 @@ Flipping an image creates a mirror image when we use ``||images:flip horizontal|
 5. Find the ``||sprites:sprite image||`` block in the sprites menu that is the image that is flipped
 
 ```blocks
-
 function flipHorizontal() {
     mySprite.image.flipX()
     pause(200)

--- a/docs/courses/csintro1/review/dodgey-duck.md
+++ b/docs/courses/csintro1/review/dodgey-duck.md
@@ -16,7 +16,6 @@ Additionally, note that this projectile will move faster as the game moves on: e
 
 ```blocks
 
-
 let mySprite: Sprite = null
 let projectile: Sprite = null
 mySprite = sprites.create(img`

--- a/docs/courses/csintro1/sprites/characters.md
+++ b/docs/courses/csintro1/sprites/characters.md
@@ -13,7 +13,6 @@ The characters are all represented as sprites, allowing them to be positioned on
 3. Save the code for the task (name it "characters")
 
 ```blocks
-
 let dorothy: Sprite = null
 let lion: Sprite = null
 let tinMan: Sprite = null

--- a/docs/courses/csintro1/sprites/collage.md
+++ b/docs/courses/csintro1/sprites/collage.md
@@ -18,7 +18,6 @@ This sprite example is larger than the default 16x16, and uses a custom variable
 [![Link to Video](/static/thumbnail_play_video.png)](https://aka.ms/40544a-collage1)
 
 ```blocks
-
 let hotSauce: Sprite = null
 scene.setBackgroundColor(1)
 hotSauce = sprites.create(img`
@@ -70,7 +69,6 @@ If the sprites are not moving to where you expect them to when you set their coo
 ### ~
 
 ```blocks
-
 let hotSauce: Sprite = null
 hotSauce = sprites.create(img`
 . . 3 . . . . 2 . . . . . . . 3 . . . . . . 3 . . . . . . . . . 

--- a/docs/courses/csintro1/sprites/coordinate-walker.md
+++ b/docs/courses/csintro1/sprites/coordinate-walker.md
@@ -19,7 +19,6 @@ Use the coordinate walker example to move around the screen and track `X` and `Y
 Open the [coordinate walker program](https://makecode.com/_huXKRL3r24iC) or open the simulator for the following code to complete the tasks.
 
 ```blocks
-
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     game.splash("X=" + Math.trunc(player1.x) + " Y=" + Math.trunc(player1.y))
 })

--- a/docs/courses/csintro1/sprites/hello-sprite.md
+++ b/docs/courses/csintro1/sprites/hello-sprite.md
@@ -23,7 +23,6 @@ A **method** is an action that an object supports. For example, sprites (an obje
 3. View the code in JavaScript
 
 ```blocks
-
 let msg: string = "Hello World!"
 let mySprite: Sprite = null
 mySprite = sprites.create(img`

--- a/docs/courses/csintro2/arrays/sprites.md
+++ b/docs/courses/csintro2/arrays/sprites.md
@@ -201,7 +201,6 @@ We can implement this behavior easily using ``||logic:logic||`` blocks in an ``|
 3. Save the code for the task (name it "itsFollowing") 
 
 ```blocks
-
 let enemy: Sprite = null
 let player: Sprite = null
 player = sprites.create(img`

--- a/docs/courses/csintro2/arrays/string.md
+++ b/docs/courses/csintro2/arrays/string.md
@@ -21,7 +21,6 @@ One way in which we can use arrays of strings is to form a "script" for our spri
 3. Save the code for the example (name it "Princess Dialogue")
 
 ```blocks
-
 let text_list: string[] = []
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
@@ -98,7 +97,6 @@ Another way in which you can use string arrays in your games is to create reacti
 3. Save the code for the example (name it "Princess Dialogue")
 
 ```blocks
-
 let text_list: string[] = []
 let mySprite: Sprite = null
 scene.onHitTile(SpriteKind.Player, 15, function (sprite) {

--- a/docs/courses/csintro2/arrays/tilemap.md
+++ b/docs/courses/csintro2/arrays/tilemap.md
@@ -19,7 +19,6 @@ In this activity, students will:
 3. Save the code for the task (name it "Get Out Of Jail Free Button") 
 
 ```blocks
-
 let myTile: tiles.Tile = null
 let mySprite: Sprite = null
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
@@ -96,7 +95,6 @@ The ``||scene:on top of myTile place mySprite||`` allows for sprites to be place
 3. Save the code for the task (name it "Random Maze")
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.onHitTile(SpriteKind.Player, 7, function (sprite) {
     game.over(true)
@@ -315,7 +313,6 @@ Using the concepts from tasks #1 and #2, the development of multi-level games be
 3. Save the code for the task (name it "move levels")
 
 ```blocks
-
 let player: Sprite = null
 let nextLevel = 0
 let levels: Image[] = []

--- a/docs/courses/csintro2/functions/extensions.md
+++ b/docs/courses/csintro2/functions/extensions.md
@@ -132,7 +132,6 @@ Do any of the names of the tabs in the explorer look similar to the name of the 
 ### ~
 
 ```blocks
-
 let projectile: Sprite = null
 projectile = sprites.createProjectile(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro2/functions/redundancy.md
+++ b/docs/courses/csintro2/functions/redundancy.md
@@ -17,7 +17,6 @@ In this activity, students will:
 3. Save the code for the example (name it "moveSprite")
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -71,7 +70,6 @@ In this case, the ``||loops:pause||``, ``||sprites:movement||``, and ``||music:t
 3. Save the code for the example (name it "moveSpriteUsingFunctions")
 
 ```blocks
-
 let mySprite: Sprite = null
 function move() {
     pause(1000)
@@ -120,7 +118,6 @@ mySprite.destroy()
 5. **Challenge:** change the behavior of the game by making the projectiles move at twice the rate in the horizontal direction (from -20 to -40), and by making the ``||music:play tone||`` block play a ``||music:Middle A||``
 
 ```blocks
-
 let projectile: Sprite = null
 projectile = sprites.createProjectile(img`
 . . . . . . . . . . . . . . . . 
@@ -203,7 +200,6 @@ game.over(false)
 5. **Challenge:** add in both a ``||sprites:set projectile ax to||`` and a ``||sprites:set projectile ay to||`` to ``||functions:function buttonPress||``, and set the newly created projectile to have random accelerations between -50 and 50
 
 ```blocks
-
 let projectile: Sprite = null
 controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
     music.playTone(415, music.beat(BeatFraction.Sixteenth))

--- a/docs/courses/csintro2/logic/booleans.md
+++ b/docs/courses/csintro2/logic/booleans.md
@@ -61,7 +61,6 @@ When we have a boolean value, we have seen that we can write code that runs when
 [Example #2](https://makecode.com/_Ug9eu36KRW2o)
 
 ```blocks
-
 let mySprite: Sprite = null
 let isHungry = false
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
@@ -117,7 +116,6 @@ We can also use the ``||logic:not||`` block when assigning a boolean. So if we w
 ## Example #3: Alternating Booleans
 
 ```blocks
-
 let projectile: Sprite = null
 let left = false
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {

--- a/docs/courses/csintro2/logic/if-else.md
+++ b/docs/courses/csintro2/logic/if-else.md
@@ -92,7 +92,6 @@ For each example below,
 [Example #1a](https://makecode.com/_HXMRAzYY4YkU)
 
 ```blocks
-
 let mySprite: Sprite = null
 let randomPick = 0
 function generate() {
@@ -138,7 +137,6 @@ generate()
 [Example #1b](https://makecode.com/_LigLWHR00d74)
 
 ```blocks
-
 let mySprite: Sprite = null
 let randomPick = 0
 function generate() {
@@ -190,7 +188,6 @@ generate()
 [Example #1c](https://makecode.com/_FDoAgwhKdh1X)
 
 ```blocks
-
 let mySprite: Sprite = null
 let randomPick = 0
 function generate() {

--- a/docs/courses/csintro2/logic/intro.md
+++ b/docs/courses/csintro2/logic/intro.md
@@ -55,7 +55,6 @@ When we make comparisons, we have two numbers, in a specific order, and what is 
 [Less Than Example](https://makecode.com/_YERAiggVK6mH)
 
 ```blocks
-
 let mySprite: Sprite = null
 let projectile: Sprite = null
 sprites.onDestroyed(SpriteKind.Enemy, function (sprite) {
@@ -223,7 +222,6 @@ When the player collects a cherry, if the player has collected more than 5, then
 [Equality Example](https://makecode.com/_3pgH9LA5kL9b)
 
 ```blocks
-
 let projectile: Sprite = null
 let mySprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {
@@ -312,7 +310,6 @@ When the player is on their final life, the image of the sprite changes and the 
 [Multiple comparisons](https://makecode.com/_FhqaRpe6Riau)
 
 ```blocks
-
 let mySprite: Sprite = null
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     if (mySprite.x < scene.screenWidth() / 2) {

--- a/docs/courses/csintro2/logic/multiplayer.md
+++ b/docs/courses/csintro2/logic/multiplayer.md
@@ -48,7 +48,6 @@ Additionally, multiple gamepads can be used to allow for more than the two playe
 2. Notice that this is the same type
 
 ```blocks
-
 let player1 = sprites.create(img`
     . . . . . . . . . . . . . . . . 
     . . . . . . . . . . . . . . . . 
@@ -95,7 +94,6 @@ In the rest of this lesson, we will implement a simple version of pong using ``|
 4. Notice how both player's scores are shown in the corners of the screen, along with the player number
 
 ```blocks
-
 let player1 = sprites.create(img`
 2 2 2 2 2 . . . . . . . . . . . 
 2 2 2 2 2 . . . . . . . . . . . 

--- a/docs/courses/csintro2/review/functions.md
+++ b/docs/courses/csintro2/review/functions.md
@@ -7,7 +7,6 @@ Functions allow for code to be structured and reused. In this example, start by 
 ## Starter Code
 
 ```blocks
-
 let mySprite: Sprite = null
 let index = 0
 controller.up.onEvent(ControllerButtonEvent.Pressed, function () {

--- a/docs/courses/csintro2/tilemap/extensions.md
+++ b/docs/courses/csintro2/tilemap/extensions.md
@@ -35,7 +35,6 @@ After adding corgio to your project, a new tab titled ``||corgio:Corgio||`` will
 4. Notice how the corgio rests on top of the wall tiles, and that the jumps reset as if the corgio were touching the bottom of the screen
 
 ```blocks
-
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 scene.setTileMap(img`
 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 

--- a/docs/courses/csintro2/tilemap/intro.md
+++ b/docs/courses/csintro2/tilemap/intro.md
@@ -254,7 +254,6 @@ In this example, the tiles are changed to correspond to images with letters on t
 [NewHome project](https://makecode.com/_2X5PdkLjp5p5)
 
 ```blocks
-
 let HomeOwner: Sprite = null
 HomeOwner = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/docs/courses/csintro3/arrays/sprites.md
+++ b/docs/courses/csintro3/arrays/sprites.md
@@ -19,8 +19,6 @@ the ``||variables:enemies||`` array
 ### Example #1a: No Arrays
 
 ```typescript
-
-
 let player: Sprite = sprites.create(sprites.castle.princessFront0, SpriteKind.Player);
 let enemy1: Sprite = sprites.create(sprites.food.smallIceCream, SpriteKind.Enemy);
 let enemy2: Sprite = sprites.create(sprites.food.smallIceCream, SpriteKind.Enemy);
@@ -36,8 +34,6 @@ enemy3.x = Math.randomRange(10, screen.width - 10);
 ### Example #1b: ``||variables:enemies||`` Array
 
 ```typescript
-
-
 let player: Sprite = sprites.create(sprites.castle.princessFront0, SpriteKind.Player);
 let enemies: Sprite[] = [
     sprites.create(sprites.food.smallIceCream, SpriteKind.Enemy),
@@ -74,8 +70,6 @@ but it can be hard to keep track of which sprites still exist when new ones get
 For example, consider the following snippet:
 
 ```typescript
-
-
 let characters: Sprite[] = [];
 
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
@@ -126,8 +120,6 @@ return an array that contains all ``||sprites:sprites||`` of a given
 identify all sprites of ``||sprites:kind||`` ``||sprites:Player||``
 
 ```typescript
-
-
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     let newCharacter: Sprite = sprites.create(sprites.food.smallPizza, SpriteKind.Player);
     newCharacter.x = Math.randomRange(0, screen.width);
@@ -188,8 +180,6 @@ with a hungry adventurer chasing the pizza around the screen.
 2. Identify how the enemy is made to "follow" the player
 
 ```typescript
-
-
 let player: Sprite = sprites.create(sprites.food.smallPizza, SpriteKind.Player);
 let enemy: Sprite = sprites.create(sprites.castle.heroWalkFront1, SpriteKind.Enemy);
 

--- a/docs/courses/csintro3/arrays/tiles.md
+++ b/docs/courses/csintro3/arrays/tiles.md
@@ -27,8 +27,6 @@ sprite interact with the scene
 event correspond to the type of tile that is used?
 
 ```typescript
-
-
 let mySprite: Sprite = sprites.create(sprites.castle.heroWalkFront1, SpriteKind.Player);
 controller.moveSprite(mySprite, 100, 100);
 

--- a/docs/courses/csintro3/events/buttons.md
+++ b/docs/courses/csintro3/events/buttons.md
@@ -77,7 +77,6 @@ instead of having to stick with the default behavior.
 3. Identify which ``||controller:button||``(s) cause the event to trigger
 
 ```typescript
-
 let mySprite: Sprite = sprites.create(sprites.castle.princessFront0, SpriteKind.Player);
 controller.left.onEvent(ControllerButtonEvent.Pressed, function () {
     mySprite.x -= 5;
@@ -106,7 +105,6 @@ Identify which events occurs
 4. Release the button, and identify which event occurs
 
 ```typescript
-
 let topSprite: Sprite = sprites.create(sprites.castle.princessFront0, SpriteKind.Player);
 let middleSprite: Sprite = sprites.create(sprites.castle.princessFront0, SpriteKind.Player);
 let bottomSprite: Sprite = sprites.create(sprites.castle.princessFront0, SpriteKind.Player);

--- a/docs/courses/csintro3/events/info-problems.md
+++ b/docs/courses/csintro3/events/info-problems.md
@@ -94,8 +94,6 @@ where the player can ``||controller:move||`` a spaceship back and forth
 and fire lasers at oncoming asteroids.
 
 ```typescript
-
-
 let mySprite: Sprite = sprites.create(img`
     . . . . . . . 5 . . . . . . .
     . . . . . . 5 4 5 . . . . . .
@@ -153,8 +151,6 @@ You can start with the example below,
 or create your own from scratch.
 
 ```typescript
-
-
 let mySprite: Sprite = sprites.create(sprites.castle.princess2Front, SpriteKind.Player);
 controller.moveSprite(mySprite);
 

--- a/docs/courses/csintro3/events/info.md
+++ b/docs/courses/csintro3/events/info.md
@@ -73,8 +73,6 @@ Notice that this is the same snippet from the examples in the
 ### ~
 
 ```typescript
-
-
 let mySprite = sprites.create(img`
     1 1 1
 `, SpriteKind.Player);

--- a/docs/courses/csintro3/events/overlap.md
+++ b/docs/courses/csintro3/events/overlap.md
@@ -34,8 +34,6 @@ the ``||sprites:sprite||`` of the other kind that is listed.
 and which is ``||variables:enemy||``
 
 ```typescript
-
-
 let mySprite = sprites.create(img`
     1 1 1
 `, SpriteKind.Player);
@@ -78,8 +76,6 @@ this can be done using ``||sprites:setFlag||``.
 into a ``||sprites:Ghost||`` 
 
 ```typescript
-
-
 let mySprite = sprites.create(img`
     1 1 1
 `, SpriteKind.Player);

--- a/docs/courses/csintro3/functions/comments.md
+++ b/docs/courses/csintro3/functions/comments.md
@@ -214,7 +214,6 @@ function lowFive(): number {
 4. **Challenge:** fill in the comment for the ``||functions:sayMyName||`` function
 
 ```typescript
-
 /**
  * 
  */

--- a/docs/courses/csintro3/structure/extensions.md
+++ b/docs/courses/csintro3/structure/extensions.md
@@ -23,13 +23,10 @@ The ``||corgio:Corgio||`` extension remains easy to use in JavaScript.
 For example, ``||corgio:corgio.create||`` can be used to create a new ``||corgio:Corgio||``.
 
 ```blocks
-
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 ```
 
 ```typescript
-
-
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 ```
 
@@ -56,14 +53,11 @@ it so the ``||corgio:Corgio||`` can move left and right across the screen.
 behavior of the ``||corgio:Corgio||``
 
 ```blocks
-
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 myCorg.horizontalMovement();
 ```
 
 ```typescript
-
-
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 myCorg.horizontalMovement();
 ```
@@ -92,8 +86,6 @@ Another feature of the ``||corgio:Corgio||`` is to maintain a group of words
 the ``||corgio:Corgio||`` has learned to ``||corgio:bark||``. 
 
 ```typescript
-
-
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 myCorg.addToScript("bark");
 myCorg.bark();

--- a/docs/courses/csintro3/structure/extensions.md
+++ b/docs/courses/csintro3/structure/extensions.md
@@ -24,7 +24,6 @@ For example, ``||corgio:corgio.create||`` can be used to create a new ``||corgio
 
 ```blocks
 
-
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 ```
 
@@ -57,7 +56,6 @@ it so the ``||corgio:Corgio||`` can move left and right across the screen.
 behavior of the ``||corgio:Corgio||``
 
 ```blocks
-
 
 let myCorg: Corgio = corgio.create(SpriteKind.Player);
 myCorg.horizontalMovement();

--- a/docs/courses/csintro3/structure/projectiles.md
+++ b/docs/courses/csintro3/structure/projectiles.md
@@ -196,8 +196,6 @@ You can find more details and examples of effects in the documentation for
 3. Identify how ``effects.blizzard`` is used to create a 'snowstorm' background
 
 ```typescript
-
-
 let myLogs = sprites.create(img`
     e e e e . . . . . e e . . . . .
     . e e e e e . e e e d e e . . .

--- a/docs/courses/csintro3/structure/sprites-problems.md
+++ b/docs/courses/csintro3/structure/sprites-problems.md
@@ -33,7 +33,6 @@ slightly different images of the same character that can be used to
 'animate' the sprite.
 
 ```typescript
-
 let duck: Sprite = sprites.create(sprites.duck.duck1, SpriteKind.Player);
 for (let i = 0; i < 10; i++) {
     duck.setImage(sprites.duck.duck1);
@@ -67,8 +66,6 @@ Add the following images to create an animation like the one below.
 Review the code in the snippet below.
 
 ```typescript
-
-
 let hero: Sprite = sprites.create(sprites.castle.heroWalkFront1, SpriteKind.Player);
 
 pause (1000);

--- a/docs/courses/csintro3/structure/sprites.md
+++ b/docs/courses/csintro3/structure/sprites.md
@@ -80,8 +80,6 @@ the image editor, and sprite ``||sprites:kinds||``.
 and the portions that are different
 
 ```typescript
-
-
 let player = sprites.create(img`
     . . . . . . b . b . . . . . . . 
     . . . . . f b b b f f . . . . . 

--- a/docs/courses/csintro3/structure/tilemaps.md
+++ b/docs/courses/csintro3/structure/tilemaps.md
@@ -69,7 +69,6 @@ are assigned a different ``||images:Image||``
 notice that the player cannot leave the ``||scene:tile map||``
 
 ```typescript
-
 let mySprite: Sprite = sprites.create(sprites.castle.heroWalkFront1, SpriteKind.Player);
 controller.moveSprite(mySprite, 100, 100);
 scene.setTileMap(img`
@@ -183,7 +182,6 @@ or blocked by ``||scene:walls||``, the ``||sprites:Ghost||`` flag can be set.
 3. Explore the "town" by moving around the screen
 
 ```typescript
-
 let mySprite: Sprite = sprites.create(sprites.castle.heroWalkFront1, SpriteKind.Player);
 scene.cameraFollowSprite(mySprite);
 controller.moveSprite(mySprite, 100, 100);

--- a/docs/courses/csintro4/appendix/anonymous.md
+++ b/docs/courses/csintro4/appendix/anonymous.md
@@ -69,8 +69,6 @@ defined to move the player and splash on the screen
 ``||functions:splashAndDash||`` to pass it as a parameter
 
 ```typescript
-
-
 function splashAndDash() {
     game.splash("Hello!");
     player.x += 5;
@@ -146,8 +144,6 @@ This task is demonstrated in the GIF below the snippet.
 pass the anonymous function itself to the function without storing it separately
 
 ```typescript
-
-
 let player: Sprite = sprites.create(img`
 1 1 1
 1 1 1

--- a/docs/courses/csintro4/appendix/for-each.md
+++ b/docs/courses/csintro4/appendix/for-each.md
@@ -44,8 +44,6 @@ all ``||sprites:Enemy||``s
 3. Identify what is done to each ``||sprites:Enemy||`` in the ``||loops:for ... of||`` loop
 
 ```typescript
-
-
 for (let i = 0; i < 15; i++) {
     let skeleton: Sprite = sprites.create(sprites.castle.skellyFront, SpriteKind.Enemy);
     skeleton.x = Math.randomRange(0, screen.width);
@@ -131,8 +129,6 @@ and then iterate over any remaining elements in the ``||arrays:array||``.
 that are on the **right** half of the screen
 
 ```typescript
-
-
 for (let i = 0; i < 15; i++) {
     let skeleton: Sprite = sprites.create(sprites.castle.skellyFront, SpriteKind.Enemy);
     skeleton.x = Math.randomRange(0, screen.width);
@@ -178,8 +174,6 @@ This is an alternate form of a function that is not covered in detail in this co
 but allows for clearer formatting when programming in this style.
 
 ```typescript
-
-
 for (let i = 0; i < 15; i++) {
     let skeleton: Sprite = sprites.create(sprites.castle.skellyFront, SpriteKind.Enemy);
     skeleton.x = Math.randomRange(0, screen.width);

--- a/docs/courses/csintro4/project-guidelines.md
+++ b/docs/courses/csintro4/project-guidelines.md
@@ -75,7 +75,6 @@ as well as a splash screen to introduce the game when it is loaded.
 ### main.ts
 
 ```typescript
-
 ```
 
 ### spritesheet.ts
@@ -94,5 +93,4 @@ namespace animations {
 ### scene.ts
 
 ```typescript
-
 ```

--- a/docs/examples/seven-segment.md
+++ b/docs/examples/seven-segment.md
@@ -20,7 +20,6 @@ game.onUpdateInterval(100, function () {
 Create 3 counters to display hours, minutes, and seconds. Set the display size of the seconds counter to `half`. Insert a sprite to show a colon character between the minutes and hours display. Use a color for the digits and screen background that will simulate the look of a LCD display.
 
 ```blocks
-
 let time = 0
 let seconds: DigitCounter = null
 let minutes: DigitCounter = null

--- a/docs/examples/sorting.md
+++ b/docs/examples/sorting.md
@@ -3,7 +3,6 @@
 Example
 
 ```typescript
-
 let arr = [1]
 for (let i = 0; i < 42; ++i)
     arr.push(Math.randomRange(10, 100))

--- a/docs/hardware/errors.md
+++ b/docs/hardware/errors.md
@@ -15,7 +15,6 @@ This error typically occurs when trying to use something that is not yet created
 for example, setting the position of a sprite that does not yet exist.
 
 ```blocks
-
 let mySprite2: Sprite = null
 let mySprite = sprites.create(img`
     . . . . . . . e c 7 . . . . . .
@@ -64,7 +63,6 @@ This can be hard to identify when games get more and more complex;
 for example, your code might rely on an object that is created by user input.
 
 ```blocks
-
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     mySprite2 = sprites.create(img`
         4 4 4 . . 4 4 4 4 4 . . . . . .

--- a/docs/lessons/barrel-dodger.md
+++ b/docs/lessons/barrel-dodger.md
@@ -9,7 +9,6 @@ Make an action game where the player has to react quickly to avoid fast moving b
 OK, let's get started by making our ``Player`` sprite. Start by placing a ``||variables:set mySprite to||`` block in an ``||loops:on start||`` block to create your sprite.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img``, SpriteKind.Player)
 ```
@@ -25,7 +24,6 @@ Draw your player sprite's image using the image editor.
 We want to put our sprite character nearer to the left side of the screen so drag a ``||sprites:set mySprite position||`` into ``||loops:on start||`` and set ``x`` to `20` and ``y`` to `70`.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . 5 . 5 . . . . . . . 
@@ -53,7 +51,6 @@ mySprite.setPosition(20, 70)
 Drag a ``||sprites:set mySprite x||`` into the ``||loops:on start||``, click the dropdown, and select ``ay (acceleration y)``. Set the value to `500` so that character is pulled down by "gravity".
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . 5 . 5 . . . . . . . 
@@ -176,7 +173,6 @@ controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
 We need to make sure that the sprite is on the ground before jumping, so drag an ``||logic:if then||`` conditional into the ``||controller:on A button pressed||``. Replace `true` with ``||scene:is mySprite hitting wall||`` and change ``left`` side ``bottom``. Finally, put in a ``||sprites:set mySprite x||`` and choose ``||sprites:vy (velocity y)||`` from the dropdown. Set the value to `-250`.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . 5 . 5 . . . . . . . 
@@ -232,7 +228,6 @@ e e e e e e e e
 Our final step is to end the game if a barrel touches the sprite player. Drag an ``||sprites:on sprite overlaps||`` onto the editor. Set the sprite kind for ``otherSprite`` to ``Projectile``. End the game with a ``||game:game over||`` block inside.
 
 ```blocks
-
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
     game.over(false)
 })
@@ -245,7 +240,6 @@ Awesome! Congratulations on making the Barrel Dodger game! You are on your way t
 ![Barrel Dodger game playing](/static/lessons/barrel-dodger/barrel-dodger.gif)
 
 ```blocks
-
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     if (mySprite.isHittingTile(CollisionDirection.Bottom)) {
         mySprite.vy = -250

--- a/docs/lessons/cherry-pickr.md
+++ b/docs/lessons/cherry-pickr.md
@@ -41,7 +41,6 @@ game.splash("Cherry Pickr")
 To set the background, click on ``||scene:Scene||`` in the Toolbox and drag the ``||scene:set tile map to||`` block into the ``||loops:on start||`` block. Go ahead and click the gray box and draw whatever you want the background to look like.
 
 ```blocks
-
 game.splash("Cherry Pickr")
 scene.setTileMap(img`
 6 6 6 6 6 6 6 6 6 6 
@@ -64,7 +63,6 @@ Our next step is to create a movable character. To do this, go to  ``||sprites:S
 Next, draw what you want the player to look like. Click the square grey box inside the ``||sprites:set mySprite to||`` block. A paint editor will pop up and this is where you will draw what you want your player to look like.
 
 ```blocks
-
 let mySprite: Sprite = null
 game.splash("Cherry Pickr")
 scene.setTileMap(img`
@@ -98,7 +96,6 @@ We do this so that when the player moves around the map, they will remain at the
 To make the player move faster, set the ``vx`` and ``vy`` to `150`.
 
 ```blocks
-
 let mySprite: Sprite = null
 game.splash("Cherry Pickr")
 scene.setTileMap(img`

--- a/docs/tutorials/chase-the-pizza.md
+++ b/docs/tutorials/chase-the-pizza.md
@@ -28,7 +28,6 @@ Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into 
 This will create a new character in the game -- but there is no image to represent this character yet.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(7)
 // @highlight
@@ -65,7 +64,6 @@ Find ``||controller:move mySprite with buttons||`` in ``||controller:Controller|
 This block allows the person playing the game to move the ``||sprites:Sprite||`` with the directional buttons; try pressing the different buttons to move your character around the screen!
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(7)
 mySprite = sprites.create(img`
@@ -97,7 +95,6 @@ Find the ``||variables:set mySprite2 to||`` block in ``||sprites:Sprites||`` and
 This will create **another** ``||sprites:Sprite||``, but one that isn't controlled by the player.
 
 ```blocks
-
 let mySprite: Sprite = null
 let pizza: Sprite = null
 scene.setBackgroundColor(7)
@@ -154,7 +151,6 @@ Find ``||info:start countdown 10s||`` in ``||info:Info||``. Drag it down to bott
 This will start a countdown that will soon end the game; we'll need to add a way to win!
 
 ```blocks
-
 let pizza: Sprite = null
 let mySprite: Sprite = null
 scene.setBackgroundColor(7)
@@ -206,7 +202,6 @@ Find the ``||sprites:on sprite overlaps otherSprite||`` block in ``||sprites:Spr
 This will create an **event** that occurs when a ``||sprites:Player Sprite||`` touches and ``||sprites:Food Sprite||``. Events allow you to set blocks to run whenever something occurs; for example, ``||loops:on start||`` is an event that lets you set code to run as soon as the game is started!
 
 ```blocks
-
 // @highlight
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
 	
@@ -218,7 +213,6 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSpr
 When an overlap is detected, the player should have a point added to their score. Find the ``||info:change score by||`` block in ``||info:Info||`` and add it to the ``||sprites:on ... overlap ...||`` event.
 
 ```blocks
-
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
     // @highlight
     info.changeScoreBy(1)
@@ -233,7 +227,6 @@ Using the ``||math:pick random||`` block, we can generate an ``x`` position from
 The screen is 160 pixels wide by 120 pixels high and we want to have the pizza away from the side so that it doesn't get clipped. 
 
 ```blocks
-
 let pizza: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
     info.changeScoreBy(1)
@@ -247,7 +240,6 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSpr
 One final thing for the overlap event, the countdown should also restart. Drag another ``||info:start countdown||`` into the ``||sprites: on ... overlap ...||`` event. Set the countdown to `3` seconds.
 
 ```blocks
-
 let pizza: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
     info.changeScoreBy(1)

--- a/docs/tutorials/galga.md
+++ b/docs/tutorials/galga.md
@@ -19,7 +19,6 @@ Get a ``||sprites:set mySprite to sprite of kind player||`` block an put it in t
 ![Space plane sprite image](/static/tutorials/galga/space-plane.jpg)
 
 ```blocks
-
 let spacePlane: Sprite = null
 spacePlane = sprites.create(img`
     . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
@@ -62,7 +61,6 @@ spacePlane = sprites.create(img`
 Go back to ``||sprites:Sprites||`` again and pull out a ``||sprites:set mySprite stay in screen||`` and put it in after the other sprite block. Change the ``||variables:mySprite||`` to ``||variables:spacePlane||``. Click the ``OFF`` button to make it switch to ``ON``. Go over to ``||info:Info||``, get a ``||info:set life to||`` block, and put it in there too. Set the life count to `3`.
 
 ```blocks
-
 let spacePlane: Sprite = null
 spacePlane = sprites.create(img`
     . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
@@ -107,7 +105,6 @@ info.setLife(3)
 Now, let's add some button actions. In ``||controller:Controller||`` pull out a ``||controller:move mySprite with buttons||``. Click on the **(+)** symbol and change both `vx` and `vy` to `200`. Next, get the ``||controller:on A button pressed||`` from ``||controller:Controller||`` and put it out in the Workspace somehwere.
 
 ```blocks
-
 let spacePlane: Sprite = null
 spacePlane = sprites.create(img`
     . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
@@ -186,7 +183,6 @@ controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
 From ``||sprites:Sprites||`` get a ``||sprites:on sprite of kind Player overlaps||`` block. Switch the second ``kind`` type at the end of the block to ``Enemy``. Pull a ``||sprites:destroy mySprite||`` in there. Go up and grab the ``||variables:otherSprite||`` from the outer block and drop it onto ``||variables:mySprite||`` in  ``||sprites:destroy mySprite||``. Go get a ``||info:change life by||`` and drop it in after ``||sprites:destroy otherSprite||``. Set the life change value to `-1`.
 
 ```blocks
-
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {
     otherSprite.destroy()
     info.changeLifeBy(-1)
@@ -198,7 +194,6 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSp
 Make a copy of ``||sprites:on sprite of kind Player overlaps||`` by clicking on it with the `right` mouse button and selecting **Duplicate**. In that new block, change the first ``kind`` from ``Player`` to ``Projectile``. Also, in the ``||info:change life by||`` make the life change value be a `1`.
 
 ```blocks
-
 sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Enemy, function (sprite, otherSprite) {
     otherSprite.destroy()
     info.changeLifeBy(1)
@@ -210,7 +205,6 @@ sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Enemy, function (sprite, oth
 Duplicate the ``||sprites:destroy otherSprite||`` and place the new copy after the first one. Like you did earlier, pull a ``||variables:sprite||`` from the ``||sprites:on sprite of kind Projectile overlaps||`` and drop it onto ``||variables:mySprite||`` in the ``||sprites:destroy sprite||`` block. Click on the **(+)** symbol and choose the ``fire`` effect. Also, set effect time to ``100 ms``.
 
 ```blocks
-
 sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Enemy, function (sprite, otherSprite) {
     otherSprite.destroy()
     sprite.destroy(effects.fire, 100)
@@ -225,7 +219,6 @@ Over in ``||game:Game||`` pickup an ``||game:on update interval||`` an place it 
 ![Enemy airplane image](/static/tutorials/galga/bogey.jpg)
 
 ```blocks
-
 let mySprite: Sprite = null
 game.onUpdateInterval(500, function () {
     mySprite = sprites.create(img`
@@ -254,7 +247,6 @@ game.onUpdateInterval(500, function () {
 Find the ``||sprites:set mySprite velocity to||`` and put it after the sprite you just made. Set `vx` to `-100`. Add in a ``||sprites:set mySprite position to||`` block. Set the `x` value to `180`. Over in ``||math:Math||``, get the ``||math:pick random||`` block and drop it into the `y` value slot.
 
 ```blocks
-
 let mySprite: Sprite = null
 game.onUpdateInterval(500, function () {
     mySprite = sprites.create(img`
@@ -285,7 +277,6 @@ game.onUpdateInterval(500, function () {
 In the ``||math:pick random||`` set the first value as `8` and the second value as `112`. Finally, click on the first ``||variables:mySprite||`` variable, select ``Rename variable...``, and rename it to ``bogey``. Did you notice that all of the ``||variables:mySprite||`` variables turned into ``||variables:bogey||``?
 
 ```blocks
-
 let bogey: Sprite = null
 game.onUpdateInterval(500, function () {
     bogey = sprites.create(img`

--- a/docs/tutorials/happy-flower.md
+++ b/docs/tutorials/happy-flower.md
@@ -17,7 +17,6 @@ Flowers make everyone around them happier, especially the bees who get nector fr
 Find ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into the ``||loops:on start||``, and draw a flower. Also, drag in a ``||scene:set background color to||`` and choose ``light blue``.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
 mySprite = sprites.create(img`
@@ -45,7 +44,6 @@ mySprite = sprites.create(img`
 Find in ``||game:on update every 500 ms||`` and ``||game:Game||``, and drag it into the workspace. Set the time to ``1000 ms``.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
 mySprite = sprites.create(img`
@@ -76,7 +74,6 @@ game.onUpdateInterval(1000, function () {
 Find ``||sprites:set projectile to projectile from mySprite||`` in ``||sprites:Sprites||``. Pull it out and put it into the ``||game:on game update every 1000 ms||``.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
 mySprite = sprites.create(img`
@@ -124,7 +121,6 @@ game.onUpdateInterval(1000, function () {
 Click on the grey box in ``||sprites:projectile||`` and make a nice little bee.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
 mySprite = sprites.create(img`
@@ -172,7 +168,6 @@ game.onUpdateInterval(1000, function () {
 Go get a ``||Math:pick random 0 to 10||``. Place it in the ``||sprites:vx||`` slot of ``||sprites:projectile||``. Change the ``0`` to ``-25`` and the ``10`` to ``25``. 
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
 mySprite = sprites.create(img`
@@ -220,7 +215,6 @@ game.onUpdateInterval(1000, function () {
 Duplicate the ``||Math:pick random -25 to 25||`` block and place it in the ``||sprites:vy||`` slot of ``||sprites:projectile||``.
 
 ```blocks
-
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
 mySprite = sprites.create(img`
@@ -270,7 +264,6 @@ Find the ``||sprites:set mySprite x to 0||`` in ``||sprites:Sprites||``, place i
 ![Adding life span](/static/tutorials/happy-flower/life-span.gif)
 
 ```blocks
-
 let projectile: Sprite = null
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
@@ -320,7 +313,6 @@ game.onUpdateInterval(1000, function () {
 Get an ``||logic:if then||`` and put it after the ``||sprites:lifespan||``. Replace the ``true`` with a ``||logic:0 < 0||``. Put a ``||sprites:mySprite x||`` in where the first `0` is. Change the ``||variables:mySprite||`` to ``||variables:projectile||`` and change the ``||sprites:x||`` to ``||sprites:vx (velocity x)||``.
 
 ```blocks
-
 let projectile: Sprite = null
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)
@@ -372,7 +364,6 @@ game.onUpdateInterval(1000, function () {
 In **Advanced** go to ``||images:Images||`` and find the ``||images:flip picture horizontally||``. Pull it out and place it into the ``||logic:if then||``. Now, back in ``||sprites:Sprites||``, get a ``||sprites:mySprite image||`` and place it in the ``||images:flip||`` where ``||variables:picture||`` is. Change the ``||variables:mySprite||`` to ``||variables:projectile||``.
 
 ```blocks
-
 let projectile: Sprite = null
 let mySprite: Sprite = null
 scene.setBackgroundColor(9)

--- a/docs/tutorials/lemon-leak.md
+++ b/docs/tutorials/lemon-leak.md
@@ -19,7 +19,6 @@ In the ``||loops:on start||`` block put in the ``||scene:set background color||`
 ![Pick the lemon image](/static/tutorials/lemon-leak/pick-a-lemon.gif)
 
 ```blocks
-
 scene.setBackgroundColor(10)
 let mySprite = sprites.create(img`
     4 4 4 . . 4 4 4 4 4 . . . . . .
@@ -47,7 +46,6 @@ controller.moveSprite(mySprite)
 To keep the lemon from leaving the screen, drag over a ``||sprites:set mySprite stay in screen||`` block. Slide the switch for it to ``ON``. Find the ``||info:start countdown||`` block and put it in at the end. Change the time from `10` to `30` seconds.
 
 ```blocks
-
 scene.setBackgroundColor(10)
 let mySprite = sprites.create(img`
     4 4 4 . . 4 4 4 4 4 . . . . . .
@@ -133,7 +131,6 @@ game.onUpdateInterval(1000, function () {
 From ``||sprites:Sprites||``, drag an ``||sprites:on sprite of kind overlaps||`` block onto the Workspace. Set the kind for ``otherSprite`` to ``Projectile``. From ``||sprites:Sprites||``, drag a ``||sprites:mySprite start effect||`` block and drop inside the ``||sprites:overlaps||`` block. Click the **(+)** icon to expand the block and set the time for the effect to ``200`` ms.
 
 ```blocks
-
 let mySprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
     mySprite.startEffect(effects.spray, 200)
@@ -145,7 +142,6 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, ot
 Lastly, to score hits by the strawberries on the lemon, drag a ``||info:change score by||`` block from ``||info:Info||`` in after the ``||sprites:mySprite start effect||`` block.
 
 ```blocks
-
 let mySprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
     mySprite.startEffect(effects.spray, 200)

--- a/docs/tutorials/simple-extensions.md
+++ b/docs/tutorials/simple-extensions.md
@@ -11,7 +11,6 @@ Extensions in @boardname@ allow users to easily develop and share portions of th
 The first thing we'll do is make our corgio. Find the ``||variables:set myCorg to||`` in ``||corgio:Corgi||``. Drag it into the ``||loops:on start||``. The corgio should appear on the left side of the screen.
 
 ```blocks
-
 let myCorg: Corgio = null
 myCorg = corgio.create(SpriteKind.Player)
 ```
@@ -21,7 +20,6 @@ myCorg = corgio.create(SpriteKind.Player)
 Now, let's make our sprite figure move left and right with the controller arrow keys. Get a ``||corgio:make myCorg move left and right with arrow keys||`` and a ``||corgio:make myCorg jump if up arrow key is pressed||`` from ``||corgio:Corgi||`` and put it under ``||variables:set myCorg to||``.
 
 ```blocks
-
 let myCorg: Corgio = null
 myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
@@ -32,7 +30,6 @@ myCorg.horizontalMovement()
 The corgio is a bit boring when it's image doesn't change; to fix this, get a ``||corgio:change image when myCorg is moving||`` block from ``||corgio:Corgio||`` and put it under ``||variables:set myCorg to||``.
 
 ```blocks
-
 let myCorg: Corgio = null
 myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
@@ -45,7 +42,6 @@ myCorg.updateSprite()
 Pull ``||scene:set tile to with wall||`` from ``||scene:Scene||`` into ``||loops:on start||``. Fill the whole tile with one color in the image editor. Click on the color bubble in ``||scene:set tile to with wall||`` and change the color index to the same color you filled the tile with. Click the ``wall`` setting to `ON`.
 
 ```blocks
-
 let myCorg: Corgio = null
 myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
@@ -78,7 +74,6 @@ Add a ``||scene:set tile map||`` to ``||loops:on start||``. For it's image, crea
 ![Drawing a platform](/static/tutorials/simple-extensions/draw-platforms.gif)
 
 ```blocks
-
 let myCorg: Corgio = null
 myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
@@ -119,7 +114,6 @@ scene.setTile(4, img`
 Open up the image editor of ``||scene:set tile map||`` again, and change the size of the image until you get to **32x8**. Draw more platforms for the corgio to jump on.
 
 ```blocks
-
 let myCorg: Corgio = null
 scene.setTileMap(img`
 . . . . . . . . . . . . . . . . . . . . . . . . . 4 . . . . . . 
@@ -160,7 +154,6 @@ scene.setTile(4, img`
 To make it so the camera follows the corgio as it leaves the screen, add ``||corgio:make camera follow myCorg left and right||`` from ``||corgio:Corgio||`` and put it under ``||variables:set myCorg to||``.
 
 ```blocks
-
 let myCorg: Corgio = null
 scene.setTileMap(img`
 . . . . . . . . . . . . . . . . . . . . . . . . . 4 . . . . . . 
@@ -204,7 +197,6 @@ At the end of the tile map, draw a column that is a different color than the cur
 ![Add winning event](/static/tutorials/simple-extensions/add-goal.png)
 
 ```blocks
-
 let myCorg: Corgio = null
 scene.setTileMap(img`
 . . . . . . . . . . . . . . . . . . . . . . . . . 4 . . . . . 7 
@@ -266,7 +258,6 @@ Add a ``||scene:on sprite of kind Player hits wall||`` block from ``||scene:Scen
 ![Add winning event](/static/tutorials/simple-extensions/game-win-event.gif)
 
 ```blocks
-
 let myCorg: Corgio = null
 scene.onHitTile(SpriteKind.Player, 7, function (sprite) {
     game.over(true)

--- a/docs/tutorials/simple-maze.md
+++ b/docs/tutorials/simple-maze.md
@@ -17,7 +17,6 @@ Welcome to @boardname@! Let's get started by creating a simple game where your p
 The first thing we'll do is make our player. Find the ``||variables:set mySprite to||`` in ``||sprites:Sprites||``. Drag it into the ``||loops:on start||``.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -46,7 +45,6 @@ Click on the grey box in ``||variables:set mySprite to||`` and draw your player'
 ![Draw a figure for the sprite](/static/tutorials/simple-maze/draw-sprite-figure.gif)
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -73,7 +71,6 @@ mySprite = sprites.create(img`
 Now, let's make our sprite figure move with the controller arrow keys. Get a ``||controller:move mySprite with buttons||`` from ``||controller:Controller||`` and put it under ``||variables:set mySprite to||``.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -101,7 +98,6 @@ controller.moveSprite(mySprite, 100, 100)
 Next, make a tile to set into the scene. Pull ``||scene:set tile to with wall||`` from ``||scene:Scene||`` into ``||loops:on start||``. Fill the whole tile with one color in the image editor.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -147,7 +143,6 @@ a a a a a a a a a a a a a a a a
 Click on the color bubble in ``||scene:set tile to with wall||`` and change the color index to the same color you filled the tile with. Turn the ``wall`` setting `ON`.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -193,7 +188,6 @@ a a a a a a a a a a a a a a a a
 Add a ``||scene:set tile map||`` to ``||loops:on start||``. For its image, draw a maze using the same color as the tile you just made. Leave an opening on the left side of the maze.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -249,7 +243,6 @@ a a a a a a a a a a
 Put a ``||info:start countdown||`` after ``||scene:set tile map||`` to set the amount of time for the game.
 
 ```blocks
-
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 


### PR DESCRIPTION
These were all added by the spritekind update and seem to be breaking translations in tutorials; crowdin seems to be converting the empty line to break tags for some reason.

Should probably handle this more gracefully in the future, but removing the new lines for now

should fix https://github.com/microsoft/pxt-arcade/issues/1173