### PR TITLE
Fixed image links

### DIFF
--- a/docs/courses/csintro1/about/authors.md
+++ b/docs/courses/csintro1/about/authors.md
@@ -4,7 +4,7 @@
 
 Eric Camplin is a Senior Content Developer at Microsoft Learning with a focus on software development for beginning programmers. He has over 19 years of industry experience in various roles. Additionally, Eric was a Public High School Teacher for 10 years, primarily in Seattle. You can follow him on Twitter at @eric_camplin.
 
-![Joey's picture](/static/courses/csintro1/about/joey.png)
+![Joey's picture](/static/courses/csintro1/about/joey.jpg)
 
 Joey Wunderlich is a Software Developer. He was a Senior TA for the Computer Science Department at the University of Washington for 8 quarters, teaching sections of the two introductory courses and the Data Structures and Algorithms course.
 

--- a/docs/courses/csintro1/project/example.md
+++ b/docs/courses/csintro1/project/example.md
@@ -10,7 +10,7 @@ After identifying three unique concepts for a game, we chose our favorite as a g
 
 We discussed the idea for the game with another group. They thought it would be cool if the trampolines moved around, making it harder for the player to score points, and we agreed.
 
-![Initial Drawing](/static/courses/csintro1/project/trampoline-drawing.png)
+![Initial Drawing](/static/courses/csintro1/project/trampoline-drawing.jpg)
 
 We create the following list of features that were the most **crucial** to implement in order to make this game fun:
 

--- a/docs/courses/csintro1/sprites/unplugged.md
+++ b/docs/courses/csintro1/sprites/unplugged.md
@@ -24,7 +24,7 @@ Your grid: Mark where your ships are and keep track of your opponent's hits and 
 
 <br />
 
-![Your Grid Example](/static/courses/csintro1/sprites/your-grid.png)
+![Your Grid Example](/static/courses/csintro1/sprites/your-grid.jpg)
 
 Opponent's grid: Keep track of your hits and misses while trying to locate your opponent's ships.
 
@@ -38,7 +38,7 @@ Opponent's grid: Keep track of your hits and misses while trying to locate your 
 
 <br />
 
-![Opponent's Grid Example](/static/courses/csintro1/sprites/opponents-grid.png)
+![Opponent's Grid Example](/static/courses/csintro1/sprites/opponents-grid.jpg)
 
 Pair up with another student. Conceal your ships on your 5x5 grid.
 

--- a/docs/courses/csintro2/about/authors.md
+++ b/docs/courses/csintro2/about/authors.md
@@ -2,7 +2,7 @@
 
 Eric Camplin is a Senior Content Developer at Microsoft Learning with a focus on software development for beginning programmers. He has over 19 years of industry experience in various roles. Additionally, Eric was a Public High School Teacher for 10 years, primarily in Seattle. You can follow him on Twitter at @eric_camplin.
 
-![Joey's picture](/static/courses/csintro2/about/joey.png)
+![Joey's picture](/static/courses/csintro2/about/joey.jpg)
 
 Joey Wunderlich is a Software Developer. He was a Senior TA for the Computer Science Department at the University of Washington for 8 quarters, teaching sections of the two introductory courses and the Data Structures and Algorithms course.
 


### PR DESCRIPTION
Some images got replaced recently from .png's to .jpg's which broke any image that linked to it.

This switches the links to point to the proper images.