### PR TITLE
Chase the pizza edit

### DIFF
--- a/docs/tutorials/chase-the-pizza.md
+++ b/docs/tutorials/chase-the-pizza.md
@@ -210,7 +210,7 @@ Open the ``||math:Math||`` Toolbox drawer and drag two ``||math:pick random||`` 
 ```blocks
 let pizza: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
-	info.changeScoreBy(1)
+    info.changeScoreBy(1)
     pizza.setPosition(Math.randomRange(0, 10), Math.randomRange(0, 10))
 })
 ```

--- a/docs/tutorials/chase-the-pizza.md
+++ b/docs/tutorials/chase-the-pizza.md
@@ -221,7 +221,10 @@ The Arcade game screen is `160` pixels wide, and `120` pixels high. In the first
 
 ```blocks
 let pizza: Sprite = null
-pizza.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+	info.changeScoreBy(1)
+    pizza.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
+})
 ```
 
 ## Step 17


### PR DESCRIPTION
Fixes #1275.

Because there was no context for this block, it was placed into the default `on start` block. Added context so that the containing block is rendered correctly.