### PR TITLE
WCAG 2.0 Level AA Alignment

### DIFF
--- a/libs/device/ns.ts
+++ b/libs/device/ns.ts
@@ -17,22 +17,22 @@ namespace scene {
 
 }
 
-//% color="#cf6a87"
+//% color="#C54C6F"
 namespace info {
 
 }
 
-//% color=#E30FC0
+//% color="#D80EB7"
 namespace music {
 
 }
 
-//% color=#B09EFF
+//% color="#7758FF"
 namespace player {
 
 }
 
-//% color=#FF5722 weight=90 advanced=true
+//% color="#DF3600" weight=90 advanced=true
 namespace control {
 
 }

--- a/libs/screen/ns.ts
+++ b/libs/screen/ns.ts
@@ -1,5 +1,5 @@
 
-//% color="#a5b1c2"
+//% color="#647894"
 namespace images {
 
 }

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -333,12 +333,12 @@
             }
         },
         "blockColors": {
-            "loops": "#20BF6B",
-            "logic": "#45AAF2",
-            "math": "#A55EEA",
-            "variables": "#EC3B59",
-            "text": "#F5D547",
-            "arrays": "#FF8F08",
+            "loops": "#17884C",
+            "logic": "#0E7AC8",
+            "math": "#9B4DE8",
+            "variables": "#E9183C",
+            "text": "#8D7408",
+            "arrays": "#B36200",
             "functions": "#1446A0"
         },
         "simAnimationEnter": "fly right in",


### PR DESCRIPTION
Fixes #1285 .

Tweak colors of blocks to align them with WCAG 2.0 Level AA standards to address accessibility concerns.

Summary of changes: (My apologies for the image; it doesn't look like I can add background colors with HTML tags here)

![WCAG 2 0 Level AA Comparison](https://user-images.githubusercontent.com/38046796/64389666-9ab3b200-d011-11e9-947d-6c7a239fdc53.png)

The new colors only change the luminosity to make them darker; the original hue and saturation are unchanged. Most of the changes are slight. __Loops__ and __Text__, though, are particularly different.

Before and after samples:

![Arcade Original Colors](https://user-images.githubusercontent.com/38046796/64389761-fbdb8580-d011-11e9-8110-408eb816a04d.png)

![Arcade WCAG 2 0 Level AA](https://user-images.githubusercontent.com/38046796/64389765-fe3ddf80-d011-11e9-9800-636f3745a1ee.png)
