### PR TITLE
fix nfl page by actually loading semantic

### DIFF
--- a/docs/nfl.html
+++ b/docs/nfl.html
@@ -7,7 +7,7 @@
     <meta name="Description" content="Football in Microsoft MakeCode Arcade" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-    <link rel="stylesheet" data-rtl="/blb/rtlsemantic.css" href="/doccdn/semantic.css">
+    <!-- @include scripthead.html -->
 
     <style>
         @media only screen and (max-width: 813px) {
@@ -27,6 +27,7 @@
 
         #root {
             background: #003399;
+            display: block !important;
         }
 
         body, h1, .ui.button {


### PR DESCRIPTION
[arcade.makecode.com/nfl](arcade.makecode.com/nfl) is looking ugly because semantic isn't being loaded properly as the doccdn isn't getting switched out; this just switches to load from scripthead in the docfiles which should get the doccdn switched out properly. Oops.

(also ``display: block !important;`` because one of the other rules from scripthead was messing up the layout by making the root flex)