### PR TITLE
fix nfl page simulator resizing

### DIFF
--- a/docs/nfl.html
+++ b/docs/nfl.html
@@ -46,7 +46,7 @@
             padding: 1.5em 3em;
             box-shadow: 15px 15px 20px 0 hsla(0, 0%, 0%, 0.3);
         }
-        
+
         #simulator {
             position: relative;
             height: 0;

--- a/docs/nfl.html
+++ b/docs/nfl.html
@@ -46,20 +46,21 @@
             padding: 1.5em 3em;
             box-shadow: 15px 15px 20px 0 hsla(0, 0%, 0%, 0.3);
         }
-
+        
         #simulator {
             position: relative;
-            width: 300px;
-            height: 380px;
+            height: 0;
+            padding-bottom: 117.6%;
             overflow: hidden;
-            margin: 1em auto;
+            margin: 1.5em 0;
         }
 
         #simulator iframe {
             position: absolute;
             top: 0;
             left: 0;
-            height: 380px;
+            width: 100%;
+            height: 105%;
         }
 
         .ui.button {
@@ -154,7 +155,7 @@
         <ol class="ui ordered list">
             <li class="bottom aligned content">First, click on the simulator below and play the game:</li>
 
-            <div id="simulator" role="presentation">
+            <div id="simulator" role="application">
                 <iframe
                     src="https://arcade.makecode.com/---run?id=_6LFCMM91ydar"
                     allowfullscreen="allowfullscreen"

--- a/docs/nfl.html
+++ b/docs/nfl.html
@@ -60,7 +60,7 @@
             top: 0;
             left: 0;
             width: 100%;
-            height: 105%;
+            height: 100%;
         }
 
         .ui.button {
@@ -157,7 +157,7 @@
 
             <div id="simulator" role="application">
                 <iframe
-                    src="https://arcade.makecode.com/---run?id=_6LFCMM91ydar"
+                    src="https://arcade.makecode.com/---run?id=_6LFCMM91ydar&nofooter=1"
                     allowfullscreen="allowfullscreen"
                     sandbox="allow-popups allow-forms allow-scripts allow-same-origin"
                     frameborder="0"

--- a/docs/nfl.html
+++ b/docs/nfl.html
@@ -52,7 +52,7 @@
             height: 0;
             padding-bottom: 117.6%;
             overflow: hidden;
-            margin: 1.5em 0;
+            margin: 1.5em auto;
         }
 
         #simulator iframe {


### PR DESCRIPTION
re: simulator being small and not working for really small phones (especially in edge with resizing issues)

Make the simulator take up a larger portion of the page and resize properly

![2019-09-30 09 51 48](https://user-images.githubusercontent.com/5615930/65899337-601b0c00-e368-11e9-8371-a221de2e5354.gif)

~~Worth noting that the 105% height on ``#simulator iframe`` is different from the default generated for simulator embeds, but I think we might need to fix something there - without it I pretty consistently get behavior where the bottom gets clipped when not focused.~~ issue is with footer not getting displayed properly.

Repros with just the default share embed https://jsfiddle.net/nqvtuyxs/1/ if it doesn't look messed up right away, you might need to click on the simulator and then click away

![2019-09-30 10 00 28](https://user-images.githubusercontent.com/5615930/65899721-2b5b8480-e369-11e9-8ec1-69013138e52a.gif)

