### PR TITLE
bump pxt to 5.26.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "typescript": "2.6.1"
   },
   "dependencies": {
-    "pxt-common-packages": "6.16.12",
-    "pxt-core": "5.26.4",
+    "pxt-common-packages": "6.16.15",
+    "pxt-core": "5.26.8",
     "@jacdac/jacdac-ts": "^0.0.9"
   },
   "optionalDependencies": {


### PR DESCRIPTION
New position picker shows a blank screen but github won't allow to upload pngs.