### PR TITLE
use rpi0 as default deploy drive

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -78,7 +78,7 @@
     ],
     "compile": {
         "useUF2": true,
-        "deployDrives": "ARCADE",
+        "deployDrives": "(ARCADE|PY)",
         "deployFileMarker": "INFO_UF2.TXT",
         "driveName": "ARCADE",
         "floatingPoint": true,

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -78,7 +78,7 @@
     ],
     "compile": {
         "useUF2": true,
-        "deployDrives": ".*",
+        "deployDrives": "ARCADE",
         "deployFileMarker": "INFO_UF2.TXT",
         "driveName": "ARCADE",
         "floatingPoint": true,


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1355 (see also https://github.com/microsoft/pxt-electron/pull/164)

infinite spinning was from an attempt to deploy to a volume that wasn't allowed on mac (and probably any wrote the file to any drives on windows, unless it silently failed?), which ended up failing to propagate the completion of the promise.

this just uses the default drive name for the rpi0, meaning it will pop up the save dialogue for any other board for now; I would think it would be ideal if boards could standardize around that one name (easier for tutorials / examples / dialogues to be consistent rather than just `drag this file over to whatever random drive shows up that wasn't there before`) but that seems unlikely

Also probably worth eventually moving hardware definitions to `targetconfig.json`, so it is updatable for offline, and then we could also define the drive name on a per-board basis if needed

edit: added `py` as a substring to match as well, as that seems to cover all current known versions (meowbit and ghi use `ARCADE-F4`, adafruit has `PYGAMERBOOT` and I believe `PYBADGEBOOT`). Otherwise, it becomes a pain to test on localhost for pygamer / etc, as it would no longer download / you'd have to use forcehexdownload all the time