### PR TITLE
make footer match background color

### DIFF
--- a/docs/nfl.html
+++ b/docs/nfl.html
@@ -112,6 +112,10 @@
         }
 
         /** footer styling **/
+        footer {
+            background-color: #003399 !important;
+        }
+
         footer.ui * {
             color: white !important;
             opacity: 0.9;


### PR DESCRIPTION
quick patch for nfl page to work with docs2.0; one of the classes added to the footer changed it's color to arcade red, otherwise everything else looked about the same already.