### PR TITLE
Codal 0.2.6 on SAMD - allows freeing PWM

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -187,7 +187,7 @@
                 "codalTarget": {
                     "name": "codal-itsybitsy-m4",
                     "url": "https://github.com/lancaster-university/codal-itsybitsy-m4",
-                    "branch": "v0.2.5",
+                    "branch": "v0.2.6",
                     "type": "git"
                 },
                 "codalBinary": "ITSYBITSY_M4",


### PR DESCRIPTION
together with https://github.com/microsoft/pxt-common-packages/pull/1005 this fixes backlight on SAMD

only new change is https://github.com/lancaster-university/codal-samd/commit/8e4b828d06c2c36dfa953467e2e9cfd135994fb5