### PR TITLE
fix category recoloring issue by fixing dependency from game to "device" pkg instead

### DIFF
--- a/libs/corgio/pxt.json
+++ b/libs/corgio/pxt.json
@@ -7,7 +7,7 @@
     ],
     "public": true,
     "dependencies": {
-        "game": "file:../game"
+        "device": "file:../device"
     },
     "weight": 79
 }

--- a/libs/darts/pxt.json
+++ b/libs/darts/pxt.json
@@ -7,7 +7,7 @@
     ],
     "public": true,
     "dependencies": {
-        "game": "file:../game"
+        "device": "file:../device"
     },
     "weight": 78
 }

--- a/libs/sevenseg/pxt.json
+++ b/libs/sevenseg/pxt.json
@@ -7,6 +7,6 @@
     ],
     "public": true,
     "dependencies": {
-        "game": "file:../game"
+        "device": "file:../device"
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/1489
along with this PR: https://github.com/microsoft/pxt-common-packages/pull/1027