### PR TITLE
Add missing block to 'Simple Extension' hint

### DIFF
--- a/docs/tutorials/simple-extensions.md
+++ b/docs/tutorials/simple-extensions.md
@@ -23,6 +23,7 @@ Now, let's make our sprite figure move left and right with the controller arrow 
 let myCorg: Corgio = null
 myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
+myCorg.verticalMovement()
 ```
 
 ## Step 3


### PR DESCRIPTION
The block for ``myCorg.verticalMovement()`` was missing in the hint for ``Step 2``.

Fixes #1535