### PR TITLE
fix snippet in name tag tutorial

### DIFF
--- a/docs/tutorials/name-tag.md
+++ b/docs/tutorials/name-tag.md
@@ -147,7 +147,7 @@ scene.setBackgroundImage(img`
 
 ## Step 3
 
-Drag a ``|sprites:start screen effect|`` block to add some cool particle animation on your tag.
+Drag a ``||scene:start screen effect||`` block to add some cool particle animation on your tag.
 
 ```blocks
 scene.setBackgroundColor(2)

--- a/docs/tutorials/name-tag.md
+++ b/docs/tutorials/name-tag.md
@@ -280,3 +280,7 @@ effects.confetti.startScreenEffect()
 ## Step 4 @unplugged
 
 Press ``||Download||`` and transfer your name tag to your device!
+
+## Complete
+
+Congratulations, your name tag is complete!


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1595

the behavior of unplugged portions only showing up on the modal and not on the step itself feels a bit off here, as the last step is unplugged too, leaving you with an empty hint; can add a last step here saying "congrats" or something of the sort?

![2019-12-17 10 50 53](https://user-images.githubusercontent.com/5615930/71025051-23cf9000-20bb-11ea-8dd5-852181f48ef7.gif)
