### PR TITLE
remove gray block from falling duck (no image.width block)

### DIFF
--- a/docs/blocks-games/duck.md
+++ b/docs/blocks-games/duck.md
@@ -524,7 +524,7 @@ game.onUpdateInterval(1500, function () {
             . . . . . . e e 6 e e e e e e 6 e e f . . . . .
         `
     }
-    gapImage = image.create(topImage.width, scene.screenHeight())
+    gapImage = image.create(2, scene.screenHeight())
     gapImage.fill(1)
     gapSprite = sprites.create(gapImage, SpriteKind.Gap)
     gapSprite.setFlag(SpriteFlag.AutoDestroy, true)


### PR DESCRIPTION
latest falling duck has a gray block at the moment, because there is no block for image.width (also having 2 here feels like it ends up overlapping more consistently with when I would expect to score, but that's arguable)