### PR TITLE
move maze tutorial to back of list

### DIFF
--- a/docs/courses/csintro3/about/start.md
+++ b/docs/courses/csintro3/about/start.md
@@ -22,7 +22,6 @@ The following tutorials may also be useful in learning about concepts that
 you might not have seen elsewhere:
 
 * [Chase the Pizza](/#tutorial:/tutorials/chase-the-pizza)
-* [Maze](/#tutorial:/tutorials/maze)
 * [Happy Flower](/#tutorial:/tutorials/happy-flower)
 * [Lemon Leak](/#tutorial:/tutorials/lemon-leak)
 * [Galga](/#tutorial:/tutorials/galga)
@@ -32,6 +31,7 @@ you might not have seen elsewhere:
 * [Picnic Food](/#tutorial:/concepts/picnic-food)
 * [Princess Pizza](/#tutorial:/concepts/princess-pizza)
 * [Bouncing Burger](/#tutorial:/concepts/bouncing-burger)
+* [Maze](/#tutorial:/tutorials/maze)
 
 Additionally, you may find it useful to check out the review material
 for the previous courses:

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -13,13 +13,6 @@
   "imageUrl": "/static/tutorials/chase-the-pizza.png",
   "largeImageUrl": "/static/tutorials/chase-the-pizza.gif"
 }, {
-  "name": "Maze",
-  "description": "Learn the basics of creating a maze",
-  "url": "/tutorials/maze",
-  "cardType": "tutorial",
-  "imageUrl": "/static/tutorials/maze.png",
-  "largeImageUrl": "/static/tutorials/maze.gif"
-}, {
   "name": "Happy Flower",
   "description": "Create a flower that sends back happy bees",
   "url": "/tutorials/happy-flower",
@@ -61,6 +54,13 @@
   "cardType": "tutorial",
   "imageUrl": "/static/tutorials/simple-extensions.png",
   "largeImageUrl": "/static/tutorials/simple-extensions.gif"
+}, {
+  "name": "Maze",
+  "description": "Learn the basics of creating a maze",
+  "url": "/tutorials/maze",
+  "cardType": "tutorial",
+  "imageUrl": "/static/tutorials/maze.png",
+  "largeImageUrl": "/static/tutorials/maze.gif"
 }
 ]
 ```


### PR DESCRIPTION
<img width="1382" alt="Screen Shot 2020-01-02 at 3 37 25 PM" src="https://user-images.githubusercontent.com/6453828/71699708-cce1e000-2d75-11ea-8c2d-cd54d2204883.png">

As per our discussions in Teams