### PR TITLE
GitHub pages cache busting

### DIFF
--- a/libs/template/.gitattributes
+++ b/libs/template/.gitattributes
@@ -1,0 +1,5 @@
+index.html linguist-generated=true
+assets/index.html linguist-generated=true
+assets/js/loader.js linguist-generated=true
+assets/js/binary.js linguist-generated=true
+assets/version.txt linguist-generated=true

--- a/libs/template/assets/index.html
+++ b/libs/template/assets/index.html
@@ -20,8 +20,12 @@
             height: 100%;
             border: none;
         }
-    </style>
-    <style>
+        #fullscreen {
+            position: absolute;
+            right: 0.25rem;
+            bottom: 0;
+            cursor: pointer;
+        }
         .lds-ripple {
             width: 80px;
             height: 80px;
@@ -93,6 +97,7 @@
     <iframe id="simframe" allowfullscreen="allowfullscreen"
         sandbox="allow-popups allow-forms allow-scripts allow-same-origin">
     </iframe>
+    <div id="fullscreen">⇲</div>
     <script type="text/javascript">
 makeCodeRun({ js: "./js/binary.js"})
         </script>

--- a/libs/template/assets/index.html
+++ b/libs/template/assets/index.html
@@ -94,7 +94,7 @@
         sandbox="allow-popups allow-forms allow-scripts allow-same-origin">
     </iframe>
     <script type="text/javascript">
-makeCodeRun({ assetsPath: "."})
+makeCodeRun({ js: "./js/binary.js"})
         </script>
 </body>
 </html>

--- a/libs/template/assets/js/loader.js
+++ b/libs/template/assets/js/loader.js
@@ -28,6 +28,7 @@ function makeCodeRun(options) {
             // load simulator with correct version
             document.getElementById("simframe")
                 .setAttribute("src", meta.simUrl);
+            initFullScreen();
         })
     }
 
@@ -119,5 +120,15 @@ function makeCodeRun(options) {
                 localStorage["simstate"] = JSON.stringify(simState)
             simStateChanged = false
         }, 200)
+    }
+    
+    function initFullScreen() {
+        var sim = document.getElementById("simframe");
+        var fs = document.getElementById("fullscreen");
+        if (fs && sim.requestFullscreen) {
+            fs.onclick = function() { sim.requestFullscreen(); }
+        } else if (fs) {
+            fs.remove();
+        }
     }
 }

--- a/libs/template/assets/js/loader.js
+++ b/libs/template/assets/js/loader.js
@@ -22,6 +22,9 @@ function makeCodeRun(options) {
             code.replace(/^\/\/\s+meta=([^\n]+)\n/m, function (m, metasrc) {
                 meta = JSON.parse(metasrc);
             })
+            var vel = document.getElementById("version");
+            if (meta.version && vel)
+                vel.innerText = "v" + meta.version;
             // load simulator with correct version
             document.getElementById("simframe")
                 .setAttribute("src", meta.simUrl);

--- a/libs/template/assets/js/loader.js
+++ b/libs/template/assets/js/loader.js
@@ -14,7 +14,7 @@ function makeCodeRun(options) {
 
     // helpers
     function fetchCode() {
-        sendReq(options.assetsPath + "/js/binary.js", function (c, status) {
+        sendReq(options.js, function (c, status) {
             if (status != 200)
                 return;
             code = c;

--- a/libs/template/index.html
+++ b/libs/template/index.html
@@ -139,6 +139,7 @@
         Made with ♡ in <a href="https://arcade.makecode.com">MakeCode</a> by <a
             href="https://github.com/{{ site.github.owner_name }}">{{ site.github.owner_name }}</a>.
         <a href="https://github.com/{{ site.github.owner_name }}/{{ site.github.repository_name }}">GitHub</a>
+        <span id="version"></span>
     </footer>
     <script type="text/javascript">makeCodeRun({ js: "./assets/js/binary.js?v={{ site.github.build_revision }}" })</script>
 </body>

--- a/libs/template/index.html
+++ b/libs/template/index.html
@@ -28,7 +28,7 @@
     <link rel="apple-touch-icon" href="./icon.png">
     <link rel="icon" type="image/png" href="./icon.png">
     <link rel="shortcut icon" href="./icon.png">
-    <script type="text/javascript" src="./assets/js/loader.js"></script>
+    <script type="text/javascript" src="./assets/js/loader.js?v={{ site.github.build_revision }}"></script>
     <style>
         body {
             background: black;
@@ -140,7 +140,7 @@
             href="https://github.com/{{ site.github.owner_name }}">{{ site.github.owner_name }}</a>.
         <a href="https://github.com/{{ site.github.owner_name }}/{{ site.github.repository_name }}">GitHub</a>
     </footer>
-    <script type="text/javascript">makeCodeRun({ assetsPath: "./assets" })</script>
+    <script type="text/javascript">makeCodeRun({ js: "./assets/js/binary.js?v={{ site.github.build_revision }}" })</script>
 </body>
 
 </html>

--- a/libs/template/index.html
+++ b/libs/template/index.html
@@ -62,8 +62,13 @@
         footer a {
             color: grey;
         }
-    </style>
-    <style>
+        
+        #fullscreen {
+            position: absolute;
+            right: 0.25rem;
+            bottom: 0;
+            cursor: pointer;
+        }
         .lds-ripple {
             width: 80px;
             height: 80px;
@@ -139,7 +144,7 @@
         Made with ♡ in <a href="https://arcade.makecode.com">MakeCode</a> by <a
             href="https://github.com/{{ site.github.owner_name }}">{{ site.github.owner_name }}</a>.
         <a href="https://github.com/{{ site.github.owner_name }}/{{ site.github.repository_name }}">GitHub</a>
-        <span id="version"></span>
+        <div id="fullscreen">⇲</div>
     </footer>
     <script type="text/javascript">makeCodeRun({ js: "./assets/js/binary.js?v={{ site.github.build_revision }}" })</script>
 </body>

--- a/libs/template/pxt.json
+++ b/libs/template/pxt.json
@@ -7,6 +7,7 @@
     },
     "files": [
         "index.html",
+        ".gitattributes",
         "assets/index.html",
         "assets/js/loader.js"
     ]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "pxt-common-packages": "6.18.2",
-    "pxt-core": "5.31.17",
+    "pxt-core": "5.31.18",
     "@jacdac/jacdac-ts": "^0.0.9"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Update template to bust cache of .js files in github pages + display version.

- [x] use github build sha to bust cache of js
- [x] add .gitattributes annotation to tell github to ignore built files in stats
- [x] full screen support in simulator