### PR TITLE
enable blocks collapsing experiment

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -386,7 +386,8 @@
             "snippetBuilder",
             "experimentalHw",
             "recipes",
-            "alwaysGithubItemBlocks"
+            "alwaysGithubItemBlocks",
+            "blocksCollapsing"
         ],
         "extendEditor": true,
         "simScreenshot": true,


### PR DESCRIPTION
Enable collapsing of blocs event as an experiment. Requires https://github.com/microsoft/pxt/pull/6487