### PR TITLE
Adding script for copying over pxt-arcade-sim

### DIFF
--- a/scripts/copyArcadeSim.js
+++ b/scripts/copyArcadeSim.js
@@ -1,0 +1,42 @@
+const fs = require("fs");
+const path = require("path");
+const rimraf = require("rimraf");
+
+const simModule = path.resolve("node_modules", "pxt-arcade-sim");
+const simSrc = path.resolve("..", "pxt-arcade-sim");
+
+if (fs.existsSync("node_modules")) {
+    console.log("Deleting " + simModule)
+    rimraf.sync(simModule);
+}
+
+shallowCopy(simSrc, simModule);
+shallowCopy(path.join(simSrc, "components"), path.join(simModule, "components"));
+shallowCopy(path.join(simSrc, "public"), path.join(simModule, "public"));
+
+const tsconfig = JSON.parse(fs.readFileSync(path.join(simModule, "tsconfig.json"), "utf8"));
+
+tsconfig.include = tsconfig.include.filter(entry => entry.indexOf("node_modules") === -1);
+
+fs.writeFileSync(path.join(simModule, "tsconfig.json"), JSON.stringify(tsconfig), "utf8")
+
+
+console.log("done")
+
+function shallowCopy(src, dest) {
+    if (!fs.existsSync(dest)) {
+        fs.mkdirSync(dest);
+    }
+    const files = fs.readdirSync(src)
+        .map(f => path.join(src, f))
+        .filter(f => !fs.lstatSync(f).isDirectory());
+
+    for (const file of files) {
+        const destPath = path.join(dest, path.basename(file));
+        const data = fs.readFileSync(file, "utf8");
+
+        console.log(`${file} -> ${destPath}`);
+
+        fs.writeFileSync(destPath, data, "utf8");
+    }
+}


### PR DESCRIPTION
Adding a script to copy over pxt-arcade-sim into a local copy of pxt-arcade (not a symlink). It both copies the relevant files and changes `tsconfig.json` so that it builds correctly.

I did not add a note to the README because the sim repo is private.

