### PR TITLE
Enabling help option in monaco

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -401,7 +401,8 @@
         "githubEditor": true,
         "githubCompiledJs": true,
         "chooseLanguageRestrictionOnNewProject": true,
-        "openProjectNewTab": true
+        "openProjectNewTab": true,
+        "hasReferenceDocs": true
     },
     "unsupportedBrowsers": [
         {


### PR DESCRIPTION
@Jaqster reported that the context menu option for launching the sidedocs in monaco wasn't working. Turns out we just never enabled it in arcade.