### PR TITLE
Insert Flipgrid links in CSIntro pages

### DIFF
--- a/docs/courses/csintro.md
+++ b/docs/courses/csintro.md
@@ -8,6 +8,12 @@ These courses are currently in beta - this means that they are likely to have bu
 
 ### ~
 
+## Courses on Flipgrid
+
+Flipcode for the **Intro to CS** course grid: **[csintroarcade](https://flipgrid.com/csintroarcade)**
+
+## Course Sections
+
 ```codecard
 [
     {

--- a/docs/courses/csintro1.md
+++ b/docs/courses/csintro1.md
@@ -6,6 +6,12 @@ This course is currently in beta - this means that it is likely to have bugs and
 
 ### ~
 
+## Course on Flipgrid
+
+Flipcode for the **Intro to CS** course grid: **[csintroarcade](https://flipgrid.com/csintroarcade)**
+
+## Lessons
+
 ```codecard
 [
 {

--- a/docs/courses/csintro1/intro.md
+++ b/docs/courses/csintro1/intro.md
@@ -41,5 +41,8 @@ This section serves as a quick introduction to the @boardname@ environment, and 
 * [Variable Math](/courses/csintro1/intro/variable-math)
 * [Info Variable Properties](/courses/csintro1/intro/info)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Introduction** chapter: https://flipgrid.com/b769222e
 
 [CS Intro Home](/courses/csintro1)

--- a/docs/courses/csintro1/loops.md
+++ b/docs/courses/csintro1/loops.md
@@ -46,5 +46,8 @@ Loops serve as a powerful tool, both to reduce redundancy in the code we write, 
 * [Physics](/courses/csintro1/loops/physics)
 * [Loops Project](/courses/csintro1/loops/project)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Loops** chapter: https://flipgrid.com/c5a85aec
 
 [CS Intro Home](/courses/csintro1)

--- a/docs/courses/csintro1/motion.md
+++ b/docs/courses/csintro1/motion.md
@@ -46,5 +46,8 @@ Motion introduces the ability to control how a sprite moves around the screen.
 * [On Created](/courses/csintro1/motion/create-on-create-sprites)
 * [Motion Project](/courses/csintro1/motion/project)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Motion** chapter: https://flipgrid.com/b66b56c7
 
 [CS Intro Home](/courses/csintro1)

--- a/docs/courses/csintro1/sprites.md
+++ b/docs/courses/csintro1/sprites.md
@@ -35,5 +35,8 @@ Sprites allow developers to fill there games with unique characters that the pla
 * [Hello Sprite](/courses/csintro1/sprites/hello-sprite)
 * [Characters and Stories](/courses/csintro1/sprites/characters)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Sprites** chapter: https://flipgrid.com/f9247917
 
 [CS Intro Home](/courses/csintro1)

--- a/docs/courses/csintro2.md
+++ b/docs/courses/csintro2.md
@@ -6,6 +6,12 @@ This course is currently in beta - this means that it is likely to have bugs and
 
 ### ~
 
+## Course on Flipgrid
+
+Flipcode for the **Intro to CS** course grid: **[csintroarcade](https://flipgrid.com/csintroarcade)**
+
+## Lessons
+
 ```codecard
 [
 {

--- a/docs/courses/csintro2/arrays.md
+++ b/docs/courses/csintro2/arrays.md
@@ -36,5 +36,8 @@ Arrays are **data structures** that allow for users to store an indefinite amoun
 * [Tile Arrays](/courses/csintro2/arrays/tilemap)
 * [Arrays Project](/courses/csintro2/arrays/project)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Arrays** chapter: https://flipgrid.com/d8680aca
 
 [CS Intro 2 Home](/courses/csintro2)

--- a/docs/courses/csintro2/functions.md
+++ b/docs/courses/csintro2/functions.md
@@ -36,5 +36,8 @@ Functions serve as a powerful tool to clarify the intent of your code, and to ma
 * [Using Extensions](/courses/csintro2/functions/extensions)
 * [Functions Project](/courses/csintro2/functions/project)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Functions** chapter: https://flipgrid.com/8b96874f
 
 [CS Intro 2 Home](/courses/csintro2)

--- a/docs/courses/csintro2/logic.md
+++ b/docs/courses/csintro2/logic.md
@@ -46,5 +46,8 @@ Logical operations allow the user to create behaviors that respond to the changi
 * [Logic in Loops](/courses/csintro2/logic/while)
 * [Logic Project](/courses/csintro2/logic/project)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Logic** chapter: https://flipgrid.com/b6f3efa8
 
 [CS Intro 2 Home](/courses/csintro2)

--- a/docs/courses/csintro2/tilemap.md
+++ b/docs/courses/csintro2/tilemap.md
@@ -31,5 +31,8 @@ Tilemaps allow you to develop levels, and define playspaces for the characters i
 * [Using Corgio Extension](/courses/csintro2/tilemap/extensions)
 * [Tilemap Project](/courses/csintro2/tilemap/project)
 
+## Flipgrid
+
+The [Flipgrid](https://info.flipgrid.com/) topic for the **Loops** chapter: https://flipgrid.com/47b27c7c
 
 [CS Intro 2 Home](/courses/csintro2)


### PR DESCRIPTION
Add the Flipgrid flipcode and topic links for CSIntro. Covers beginner courses 1 & 2.