### PR TITLE
add note on color-coded-tilemap, and import pkg

### DIFF
--- a/docs/courses/csintro2/arrays/project.md
+++ b/docs/courses/csintro2/arrays/project.md
@@ -68,7 +68,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -81,7 +81,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -97,7 +97,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro2/arrays/string.md
+++ b/docs/courses/csintro2/arrays/string.md
@@ -8,6 +8,21 @@ In this activity, students will:
 * Interact with string arrays
 * Use arrays with loops
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
 ## Concept: Arrays for dialogue
 
 One way in which we can use arrays of strings is to form a "script" for our sprites to follow. By keeping the script inside of an array, you are able to keep it all located in one place - so if you need to fix a typo, or add in a new line, all the content remains in a single location for you to see.
@@ -182,3 +197,7 @@ corgio
 2. In task #1a, why did we use the ``||arrays:length of array||`` instead of just setting it to the new length (for example, changing it to be from `0 to 3` to `0 to 6`)?
 
 ### [Teacher Material](/courses/csintro2/about/teachers)
+
+```package
+color-coded-tilemap
+```

--- a/docs/courses/csintro2/arrays/string.md
+++ b/docs/courses/csintro2/arrays/string.md
@@ -23,6 +23,10 @@ If you wish to use these blocks in another project, they can be added using the 
 
 ### ~
 
+```package
+color-coded-tilemap
+```
+
 ## Concept: Arrays for dialogue
 
 One way in which we can use arrays of strings is to form a "script" for our sprites to follow. By keeping the script inside of an array, you are able to keep it all located in one place - so if you need to fix a typo, or add in a new line, all the content remains in a single location for you to see.
@@ -197,7 +201,3 @@ corgio
 2. In task #1a, why did we use the ``||arrays:length of array||`` instead of just setting it to the new length (for example, changing it to be from `0 to 3` to `0 to 6`)?
 
 ### [Teacher Material](/courses/csintro2/about/teachers)
-
-```package
-color-coded-tilemap
-```

--- a/docs/courses/csintro2/arrays/tilemap.md
+++ b/docs/courses/csintro2/arrays/tilemap.md
@@ -8,6 +8,25 @@ In this activity, students will:
 * Create a 'trap room'
 * Create a series of multiple levels
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Concept: Tiles
 
 [![Link to Video](/static/thumbnail_play_video.png)](https://aka.ms/40546a-array-tile1)

--- a/docs/courses/csintro2/functions/project.md
+++ b/docs/courses/csintro2/functions/project.md
@@ -67,7 +67,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -80,7 +80,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -96,7 +96,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro2/logic/project.md
+++ b/docs/courses/csintro2/logic/project.md
@@ -72,7 +72,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -85,7 +85,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -101,7 +101,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro2/review/side-scroller.md
+++ b/docs/courses/csintro2/review/side-scroller.md
@@ -6,6 +6,25 @@ In this activity, you will build your own side-scrolling adventure where a car t
 
 ![Block Bouncer](/static/courses/csintro2/review/side-scroller.gif)
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Starter Code
 
 Create a project with the code below - the images for the trees and car are available in the Gallery.

--- a/docs/courses/csintro2/tilemap/extensions.md
+++ b/docs/courses/csintro2/tilemap/extensions.md
@@ -9,6 +9,25 @@ In this activity, students will:
 * Design their own levels using a ``||scene:tilemap||``
 * Implement a platformer game
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Using the corgio package
 
 ``||corgio:corgio||`` allows you to create a sprite who can jump, run, and fall with only a few blocks in the ``||loops:on start||``.

--- a/docs/courses/csintro2/tilemap/interactions.md
+++ b/docs/courses/csintro2/tilemap/interactions.md
@@ -10,6 +10,25 @@ In this activity, students will use:
 * ``||scene:on sprite of kind hits wall||``
 * ``||scene:set tilemap to||``
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Example #1: Creating a course
 
 [![Link to Video](/static/thumbnail_play_video.png)](https://aka.ms/40544a-tilemap-golf )

--- a/docs/courses/csintro2/tilemap/intro.md
+++ b/docs/courses/csintro2/tilemap/intro.md
@@ -10,6 +10,25 @@ In this activity, students will:
 * Personalize the tiles in the tilemap
 * "Decorate" a house
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Concept: Editing a tilemap
 
 The tilemap uses an image to represent a game space that is often much larger than the visible game screen.

--- a/docs/courses/csintro2/tilemap/project.md
+++ b/docs/courses/csintro2/tilemap/project.md
@@ -71,7 +71,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -84,7 +84,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -100,7 +100,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro3/arrays/project.md
+++ b/docs/courses/csintro3/arrays/project.md
@@ -21,7 +21,7 @@ Make your own unique games!
 
 ## Student Task #1: Initial Ideas
 
-1. Think of **at least** 3 ideas for games that use some of the "concepts learned" listed above. 
+1. Think of **at least** 3 ideas for games that use some of the "concepts learned" listed above.
 2. On a piece of paper, sketch out what each game will look like
 3. Discuss your ideas with a partner. Talk about:
     * What you like about the ideas
@@ -62,7 +62,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -75,7 +75,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -91,7 +91,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro3/arrays/tiles-problems.md
+++ b/docs/courses/csintro3/arrays/tiles-problems.md
@@ -5,6 +5,25 @@ This section contains a number of selected problems for the Tiles section.
 It is recommended that you review the problems, and complete a few before
 moving on to the next section.
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Problem #1: Road Building
 
 Create a small, rectangular road with the ``||scene:tilemap||`` below.

--- a/docs/courses/csintro3/arrays/tiles.md
+++ b/docs/courses/csintro3/arrays/tiles.md
@@ -7,6 +7,25 @@ that the player can explore.
 control over how developers can interact with the individual ``||scene:tiles||``
 that make up the ``||scene:tilemap||``.
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Concept: On Hit Tile Events
 
 The ``||scene:scene.onHitTile||`` event occurs when a sprite of the given

--- a/docs/courses/csintro3/events/info-problems.md
+++ b/docs/courses/csintro3/events/info-problems.md
@@ -5,6 +5,25 @@ This section contains a number of selected problems for the Info section.
 It is recommended that you review the problems, and complete a few before
 moving on to the next section.
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Problem #1: Dodge to Win
 
 Create a game where the player must avoid asteroids for 30 seconds to win.

--- a/docs/courses/csintro3/events/project.md
+++ b/docs/courses/csintro3/events/project.md
@@ -21,7 +21,7 @@ Make your own unique games!
 
 ## Student Task #1: Initial Ideas
 
-1. Think of **at least** 3 ideas for games that use some of the "concepts learned" listed above. 
+1. Think of **at least** 3 ideas for games that use some of the "concepts learned" listed above.
 2. On a piece of paper, sketch out what each game will look like
 3. Discuss your ideas with a partner. Talk about:
     * What you like about the ideas
@@ -62,7 +62,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -75,7 +75,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -91,7 +91,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro3/functions/project.md
+++ b/docs/courses/csintro3/functions/project.md
@@ -61,7 +61,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -74,7 +74,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -90,7 +90,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro3/structure/project.md
+++ b/docs/courses/csintro3/structure/project.md
@@ -64,7 +64,7 @@ For a guided example of this process, [see the example project page.](/courses/c
 
 ### ~hint
 
-### Build
+#### Build
 
 Implement a list of features
 
@@ -77,7 +77,7 @@ Implement a list of features
 
 ### ~hint
 
-### Test
+#### Test
 
 Gather feedback about the game from an outside source
 
@@ -93,7 +93,7 @@ Gather feedback about the game from an outside source
 
 ### ~hint
 
-### Learn
+#### Learn
 
 Convert the feedback into a list of features that to implement
 

--- a/docs/courses/csintro3/structure/tilemaps-problems.md
+++ b/docs/courses/csintro3/structure/tilemaps-problems.md
@@ -5,6 +5,25 @@ This section contains a number of selected problems for the Tilemaps section.
 It is recommended that you review the problems, and complete a few before
 moving on to the next section.
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Problem #1: Say Hi!
 
 Using only ``||scene:scene.setTileMap||``, create an **8 x 8** ``||scene:tilemap||``

--- a/docs/courses/csintro3/structure/tilemaps.md
+++ b/docs/courses/csintro3/structure/tilemaps.md
@@ -6,6 +6,25 @@ Well designed maps can serve as a world for the player to explore,
 and can be easily populated with distinct images for each tile that
 make the world more visually appealing.
 
+### ~hint
+
+#### Color Coded Tilemap
+
+This section uses the color coded tilemap in some of the examples.
+
+These were the original style of tilemaps, that got replaced with new blocks prior to the release of arcade.
+The new blocks show the tilemap in full as you draw it, allow more tiles at once, and let you set tiles as walls without changing the image.
+
+If you open any example using the edit button, the extension will be automatically added to the project.
+
+If you wish to use these blocks in another project, they can be added using the `color-coded-tilemap` extension.
+
+### ~
+
+```package
+color-coded-tilemap
+```
+
 ## Concept: Creating a Tilemap
 
 The ``||scene:scene.setTileMap||`` function is used to create a tilemap.


### PR DESCRIPTION
Apparently the snippets in the course never got the package snippet, and I had never noticed because they just showed gray blocks (as the color-coded-tilemap extension just adds the block definitions)

Adds a little header to those pages explaining why they use different blocks, and include the package so the snippets don't get gray blocks:

![image](https://user-images.githubusercontent.com/5615930/78208270-d05e3380-7458-11ea-8228-01137913b77b.png)

re: https://forum.makecode.com/t/noob-question-unable-to-create-stage-map-for-the-game/1571/3?u=jwunderl

also fixed the project subheadings on hints, as they looked wonky; with this they'll show up on the same line as the hint icon, rather than underneath:

![image](https://user-images.githubusercontent.com/5615930/78209075-eec52e80-745a-11ea-9e79-b8d7f826ea22.png)

![image](https://user-images.githubusercontent.com/5615930/78209090-f8e72d00-745a-11ea-9a98-5561473848a5.png)


worth noting we can't really upgrade course 3 fully right now, as that one's js based and there is currently no tilemap editor in monaco; color-coded-tilemap is the only option staying in there atm