### PR TITLE
Adding settings package to preferred list

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -13,7 +13,8 @@
             "adafruit/Circuit-Playground-Character-Icons",
             "adafruit/pxt-seesaw",
             "jwunderl/pxt-button-combos",
-            "jwunderl/pxt-color"
+            "jwunderl/pxt-color",
+            "microsoft/pxt-settings-blocks"
         ]
     },
     "galleries": {

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -7,7 +7,8 @@
             "adafruit/Circuit-Playground-Character-Icons",
             "adafruit/pxt-seesaw",
             "jwunderl/pxt-button-combos",
-            "jwunderl/pxt-color"
+            "jwunderl/pxt-color",
+            "microsoft/pxt-settings-blocks"
         ],
         "preferredRepos": [
             "adafruit/Circuit-Playground-Character-Icons",


### PR DESCRIPTION
I created [this extension](https://github.com/microsoft/pxt-settings-blocks) to wrap the settings namespace for blocks. Adding this to the preferred repo list so that it shows up in the extensions dialog. 

The settings blocks can be used to save/restore data for a game in between runs. For example, you can use it to save your progress in a long game, track how many times a player has died, etc. The blocks are below

<img width="606" alt="Screen Shot 2020-04-03 at 10 34 28 AM" src="https://user-images.githubusercontent.com/13754588/78389074-f558c080-7596-11ea-9b36-8c715b2bcb22.png">


