### PR TITLE
Set WIN for 'Simple Extensions'

### DIFF
--- a/docs/tutorials/simple-extensions.md
+++ b/docs/tutorials/simple-extensions.md
@@ -215,7 +215,7 @@ namespace myTiles {
     `
 }
 scene.onOverlapTile(SpriteKind.Player, sprites.builtin.coral0, function (sprite, location) {
-    game.over(false)
+    game.over(true)
 })
 let myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()


### PR DESCRIPTION
Set `game.over(true)` so **WIN** shows in the snippet block. This matches the description.

Fixes #1995