### PR TITLE
Spyify tutorials

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -15,10 +15,6 @@
   "videoUrl": "/static/tutorials/chase-the-pizza.mp4",
   "otherActions": [{
     "url": "/tutorials/spy/chase-the-pizza",
-    "editor": "py",
-    "cardType": "tutorial"
-  }, {
-    "url": "/tutorials/spy/chase-the-pizza",
     "editor": "js",
     "cardType": "tutorial"
   }]
@@ -32,10 +28,6 @@
   "videoUrl": "/static/tutorials/happy-flower.mp4",
   "otherActions": [{
     "url": "/tutorials/spy/happy-flower",
-    "editor": "py",
-    "cardType": "tutorial"
-  }, {
-    "url": "/tutorials/spy/happy-flower",
     "editor": "js",
     "cardType": "tutorial"
   }]
@@ -48,10 +40,6 @@
   "largeImageUrl": "/static/tutorials/lemon-leak.gif",
   "videoUrl": "/static/tutorials/lemon-leak.mp4",
   "otherActions": [{
-    "url": "/tutorials/spy/lemon-leak",
-    "editor": "py",
-    "cardType": "tutorial"
-  }, {
     "url": "/tutorials/spy/lemon-leak",
     "editor": "js",
     "cardType": "tutorial"

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -12,7 +12,16 @@
   "cardType": "tutorial",
   "imageUrl": "/static/tutorials/chase-the-pizza.png",
   "largeImageUrl": "/static/tutorials/chase-the-pizza.gif",
-  "videoUrl": "/static/tutorials/chase-the-pizza.mp4"
+  "videoUrl": "/static/tutorials/chase-the-pizza.mp4",
+  "otherActions": [{
+    "url": "/tutorials/spy/chase-the-pizza",
+    "editor": "py",
+    "cardType": "tutorial"
+  }, {
+    "url": "/tutorials/spy/chase-the-pizza",
+    "editor": "js",
+    "cardType": "tutorial"
+  }]
 }, {
   "name": "Happy Flower",
   "description": "Create a flower that sends back happy bees",
@@ -20,7 +29,16 @@
   "cardType": "tutorial",
   "imageUrl": "/static/tutorials/happy-flower.png",
   "largeImageUrl": "/static/tutorials/happy-flower.gif",
-  "videoUrl": "/static/tutorials/happy-flower.mp4"
+  "videoUrl": "/static/tutorials/happy-flower.mp4",
+  "otherActions": [{
+    "url": "/tutorials/spy/happy-flower",
+    "editor": "py",
+    "cardType": "tutorial"
+  }, {
+    "url": "/tutorials/spy/happy-flower",
+    "editor": "js",
+    "cardType": "tutorial"
+  }]
 }, {
   "name": "Lemon Leak",
   "description": "Stay away from the wild strawberries or you'll lose your juice!",
@@ -28,7 +46,16 @@
   "cardType": "tutorial",
   "imageUrl": "/static/tutorials/lemon-leak.png",
   "largeImageUrl": "/static/tutorials/lemon-leak.gif",
-  "videoUrl": "/static/tutorials/lemon-leak.mp4"
+  "videoUrl": "/static/tutorials/lemon-leak.mp4",
+  "otherActions": [{
+    "url": "/tutorials/spy/lemon-leak",
+    "editor": "py",
+    "cardType": "tutorial"
+  }, {
+    "url": "/tutorials/spy/lemon-leak",
+    "editor": "js",
+    "cardType": "tutorial"
+  }]
 }, {
   "name": "Galga",
   "description": "Fly through the attacking spacecraft and fire darts at them, don't get hit!",
@@ -36,7 +63,8 @@
   "cardType": "tutorial",
   "imageUrl": "/static/tutorials/galga.png",
   "largeImageUrl": "/static/tutorials/galga.gif",
-  "videoUrl": "/static/tutorials/galga.mp4"
+  "videoUrl": "/static/tutorials/galga.mp4",
+  "otherActions": []
 }, {
   "name": "Free Throw",
   "description": "Take your best shot and slam dunk this Basketball free throw game!",
@@ -66,7 +94,8 @@
   "cardType": "tutorial",
   "imageUrl": "/static/tutorials/paddle.png",
   "largeImageUrl": "/static/tutorials/paddle.gif",
-  "videoUrl": "/static/tutorials/paddge.mp4"
+  "videoUrl": "/static/tutorials/paddge.mp4",
+  "otherActions": []
 }, {
   "name": "Name Tag",
   "description": "A simple name tag with cool effects",

--- a/docs/tutorials/spy/chase-the-pizza.md
+++ b/docs/tutorials/spy/chase-the-pizza.md
@@ -56,9 +56,8 @@ Use the color palette and design tools to draw an image on the canvas. Click **D
 Put in the code to ``||controller:move mySprite||`` with the ``||controller:controller||``.
 
 ```spy
-let mySprite: Sprite = null
 scene.setBackgroundColor(7)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . . . 5 5 5 5 5 5 . . . . . 
 . . . 5 5 5 5 5 5 5 5 5 5 . . . 
 . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
@@ -86,10 +85,8 @@ Just like with ``||variables:mySprite||``, ``||create a sprite||`` again and set
 be the **pizza** sprite in our game.
 
 ```spy
-let mySprite: Sprite = null
-let mySprite2: Sprite = null
 scene.setBackgroundColor(7)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . . . 5 5 5 5 5 5 . . . . . 
 . . . 5 5 5 5 5 5 5 5 5 5 . . . 
 . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
@@ -188,10 +185,9 @@ Let’s restart our countdown each time. Add the code to ``||info:start countdow
 count be `10`.
 
 ```spy
-let pizza: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
 	info.changeScoreBy(1)
-    pizza.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
+    otherSprite.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
     info.startCountdown(10)
 })
 ```
@@ -201,10 +197,8 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSpr
 Congratulations, you have completed your game! Use the Game Simulator to play by moving your ``||sprites:Player||`` around the screen to try and eat as much pizza as possible before the time runs out. What’s your high score?
 
 ```spy
-let pizza: Sprite = null
-let mySprite: Sprite = null
 scene.setBackgroundColor(7)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . . . 5 5 5 5 5 5 . . . . . 
 . . . 5 5 5 5 5 5 5 5 5 5 . . . 
 . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
@@ -223,7 +217,7 @@ mySprite = sprites.create(img`
 . . . . . 5 5 5 5 5 5 . . . . . 
 `, SpriteKind.Player)
 controller.moveSprite(mySprite)
-pizza = sprites.create(img`
+let pizza = sprites.create(img`
 . . . . . . b b b b . . . . . .
 . . . . . . b 4 4 4 b . . . . .
 . . . . . . b b 4 4 4 b . . . .
@@ -244,7 +238,7 @@ b 5 5 5 5 d d 4 4 4 4 . . . . .
 
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
 	info.changeScoreBy(1)
-    pizza.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
+    otherSprite.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
     info.startCountdown(10)
 })
 ```

--- a/docs/tutorials/spy/chase-the-pizza.md
+++ b/docs/tutorials/spy/chase-the-pizza.md
@@ -105,7 +105,7 @@ let mySprite = sprites.create(img`
 . . . . . 5 5 5 5 5 5 . . . . .
 `, SpriteKind.Player)
 controller.moveSprite(mySprite)
-pizza = sprites.create(img`
+let pizza = sprites.create(img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 

--- a/docs/tutorials/spy/chase-the-pizza.md
+++ b/docs/tutorials/spy/chase-the-pizza.md
@@ -200,7 +200,7 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSpr
 
 Congratulations, you have completed your game! Use the Game Simulator to play by moving your ``||sprites:Player||`` around the screen to try and eat as much pizza as possible before the time runs out. What’s your high score?
 
-```blocks
+```spy
 let pizza: Sprite = null
 let mySprite: Sprite = null
 scene.setBackgroundColor(7)

--- a/docs/tutorials/spy/chase-the-pizza.md
+++ b/docs/tutorials/spy/chase-the-pizza.md
@@ -1,0 +1,250 @@
+# Chase the Pizza
+
+### @explicitHints true
+
+## Introduction @unplugged
+
+![Game animation](/static/tutorials/chase-the-pizza.gif)
+
+In this tutorial you will create a game with 2 sprites, a ``||sprites:Player||`` sprite and a ``||sprites:Food||`` sprite. The goal of the game is to eat as much pizza as you can before the time runs out! Each time your player catches the pizza, you gain points and the countdown is restarted.
+
+## Step 1
+
+First, ``||scene:set background color||`` to a color you like. To see what this looks like in your game, look at the Game Simulator on the left side of the screen.
+
+```spy
+scene.setBackgroundColor(0)
+```
+
+## Step 2
+
+Add code to ``||sprites:create a sprite||`` a set it to a variable name ``||variables:mySprite||``. Use
+``||sprites:Player||`` for the ``||sprites:sprite kind||``.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(7)
+mySprite = sprites.create(img`
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+`, SpriteKind.Player)
+```
+
+## Step 3
+
+Draw your ``||sprites:Player||`` character by using the image editor for  ``||variables:set mySprite||``.
+Use the color palette and design tools to draw an image on the canvas. Click **Done** when you are finished.
+
+![Image editor](/static/tutorials/chase-the-pizza/image-editor.gif)
+
+## Step 4
+
+Put in the code to ``||controller:move mySprite||`` with the ``||controller:controller||``.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(7)
+mySprite = sprites.create(img`
+. . . . . 5 5 5 5 5 5 . . . . . 
+. . . 5 5 5 5 5 5 5 5 5 5 . . . 
+. . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+. 5 5 5 5 5 5 5 5 5 5 5 5 5 5 . 
+. 5 5 5 f f 5 5 5 5 f f 5 5 5 .
+5 5 5 5 f f 5 5 5 5 f f 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 f 5 5 5 5 5 5 5 5 5 5 f 5 5 
+5 5 5 f 5 5 5 5 5 5 5 5 f 5 5 5 
+. 5 5 5 f 5 5 5 5 5 5 f 5 5 5 . 
+. 5 5 5 5 f f f f f f 5 5 5 5 . 
+. . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+. . . 5 5 5 5 5 5 5 5 5 5 . . . 
+. . . . . 5 5 5 5 5 5 . . . . .
+`, SpriteKind.Player)
+controller.moveSprite(mySprite)
+```
+
+## Step 5
+
+Just like with ``||variables:mySprite||``, ``||create a sprite||`` again and set it to the a variable named
+``||variables:pizza||``. This time, set the ``||sprites:sprite kind||`` to ``||sprites:food||``. This will
+be the **pizza** sprite in our game.
+
+```spy
+let mySprite: Sprite = null
+let mySprite2: Sprite = null
+scene.setBackgroundColor(7)
+mySprite = sprites.create(img`
+. . . . . 5 5 5 5 5 5 . . . . . 
+. . . 5 5 5 5 5 5 5 5 5 5 . . . 
+. . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+. 5 5 5 5 5 5 5 5 5 5 5 5 5 5 . 
+. 5 5 5 f f 5 5 5 5 f f 5 5 5 .
+5 5 5 5 f f 5 5 5 5 f f 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 f 5 5 5 5 5 5 5 5 5 5 f 5 5 
+5 5 5 f 5 5 5 5 5 5 5 5 f 5 5 5 
+. 5 5 5 f 5 5 5 5 5 5 f 5 5 5 . 
+. 5 5 5 5 f f f f f f 5 5 5 5 . 
+. . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+. . . 5 5 5 5 5 5 5 5 5 5 . . . 
+. . . . . 5 5 5 5 5 5 . . . . .
+`, SpriteKind.Player)
+controller.moveSprite(mySprite)
+pizza = sprites.create(img`
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+`, SpriteKind.Food)
+```
+
+## Step 6
+
+Use the image editor for ``||variables:pizza||`` and then select the **Gallery** view. Scroll to find the image of a small pizza (or any other image you like!) and select it to load into the image editor.
+
+![Image gallery](/static/tutorials/chase-the-pizza/image-gallery.gif)
+
+## Step 7 @resetDiff
+
+Add a ``||sprites:on overlap||`` event to your code. Set the ``||sprites:sprite kind||`` that cooresponds to
+``otherSprite`` as ``||sprites:Food||``.
+
+```spy
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+	
+})
+```
+
+## Step 8
+
+When our ``||sprites:Player||`` overlaps with the ``||variables:pizza||`` sprite, let’s add a point to our game score. Pun in the code to ``||info:change score by||`` 1`.
+
+```spy
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+	info.changeScoreBy(1)
+})
+```
+
+## Step 9
+
+Let’s set the position for ``||variables:pizza||`` to random locations around the screen. We use
+``otherSprite`` and ``||sprites:set its position||``. Righy now, just use `0` for both `x` and `y`.
+
+```spy
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+	info.changeScoreBy(1)
+    otherSprite.setPosition(0, 0)
+})
+```
+
+## Step 10
+
+Put in code for the `x` and `y` positions of ``otherSprite`` to use a ``||math:pick a random||`` number.
+The Arcade game screen is `160` pixels wide, and `120` pixels high. In the first ``||math:pick random||``
+in the `x` coordinate of the ``||sprites:otherSprite position||``, change the maximum value from **0** to
+**160**. In the second ``||math:pick random||`` in the ``y`` coordinate, change the maximum value from
+**0** to **120**.
+
+```spy
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+	info.changeScoreBy(1)
+    otherSprite.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
+})
+```
+
+## Step 11
+
+Let’s restart our countdown each time. Add the code to ``||info:start countdown||`` and make the countdown
+count be `10`.
+
+```spy
+let pizza: Sprite = null
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+	info.changeScoreBy(1)
+    pizza.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
+    info.startCountdown(10)
+})
+```
+
+## Complete @resetDiff
+
+Congratulations, you have completed your game! Use the Game Simulator to play by moving your ``||sprites:Player||`` around the screen to try and eat as much pizza as possible before the time runs out. What’s your high score?
+
+```blocks
+let pizza: Sprite = null
+let mySprite: Sprite = null
+scene.setBackgroundColor(7)
+mySprite = sprites.create(img`
+. . . . . 5 5 5 5 5 5 . . . . . 
+. . . 5 5 5 5 5 5 5 5 5 5 . . . 
+. . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+. 5 5 5 5 5 5 5 5 5 5 5 5 5 5 . 
+. 5 5 5 f f 5 5 5 5 f f 5 5 5 .
+5 5 5 5 f f 5 5 5 5 f f 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
+5 5 f 5 5 5 5 5 5 5 5 5 5 f 5 5 
+5 5 5 f 5 5 5 5 5 5 5 5 f 5 5 5 
+. 5 5 5 f 5 5 5 5 5 5 f 5 5 5 . 
+. 5 5 5 5 f f f f f f 5 5 5 5 . 
+. . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+. . . 5 5 5 5 5 5 5 5 5 5 . . . 
+. . . . . 5 5 5 5 5 5 . . . . . 
+`, SpriteKind.Player)
+controller.moveSprite(mySprite)
+pizza = sprites.create(img`
+. . . . . . b b b b . . . . . .
+. . . . . . b 4 4 4 b . . . . .
+. . . . . . b b 4 4 4 b . . . .
+. . . . . b 4 b b b 4 4 b . . .
+. . . . b d 5 5 5 4 b 4 4 b . .
+. . . . b 3 2 3 5 5 4 e 4 4 b .
+. . . b d 2 2 2 5 7 5 4 e 4 4 e
+. . . b 5 3 2 3 5 5 5 5 e e e e
+. . b d 7 5 5 5 3 2 3 5 5 e e e
+. . b 5 5 5 5 5 2 2 2 5 5 d e e
+. b 3 2 3 5 7 5 3 2 3 5 d d e 4
+. b 2 2 2 5 5 5 5 5 5 d d e 4 .
+b d 3 2 d 5 5 5 d d d 4 4 . . .
+b 5 5 5 5 d d 4 4 4 4 . . . . .
+4 d d d 4 4 4 . . . . . . . . .
+4 4 4 4 . . . . . . . . . . . .
+`, SpriteKind.Food)
+
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+	info.changeScoreBy(1)
+    pizza.setPosition(Math.randomRange(0, 160), Math.randomRange(0, 120))
+    info.startCountdown(10)
+})
+```

--- a/docs/tutorials/spy/happy-flower.md
+++ b/docs/tutorials/spy/happy-flower.md
@@ -1,0 +1,425 @@
+# Happy Flower
+
+### @explicitHints true
+
+## Introduction @unplugged
+
+Flowers make everyone around them happier, especially the bees who get nectar from them. To show this, we can create a flower that sends happy little bees back to the hive.
+
+![Happy thoughts](/static/tutorials/happy-flower/happy-thoughts.gif)
+
+## Step 1
+
+First, ``||scene:set background color to||`` ``light blue``. Create a new sprite called ``||variables:mySprite||``. Draw a flower as the image for the sprite.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . .
+`, SpriteKind.Player)
+```
+
+## Step 2
+
+Put in an ``||game:on update||`` event for an interval of ``1000`` milliseconds.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . .
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+
+})
+```
+
+## Step 3
+
+Add code in the ``||game:on game update interval||`` event to set a ``||variables:projectile||``
+variable to a ``||sprites:projectile sprite from||`` the ``||variables:mySprite||``
+sprite. Set the velocities for both ``vx`` and ``vy`` to `0`.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . .
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    let projectile = sprites.createProjectileFromSprite(img`
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+`, mySprite, 0, 0)
+})
+```
+
+## Step 4
+
+In the image editor for ``||sprites:projectile||``, make a nice little bee.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . . 
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    let projectile = sprites.createProjectileFromSprite(img`
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . b b . . b . . . . . . .
+. . . . . b b b b . . . . . . .
+. . . . . . . b b . . . . . . .
+. . . . . f 5 f 5 f . . . . . .
+. . . . 5 f 5 f 5 f 1 . . . . .
+. . . . 5 f 5 f 5 f 5 b . . . .
+. . . . . . 5 f 5 f 5 . . . . .
+. . . . . e . . . e . . . . . .
+. . . . e . . . . e . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+`, mySprite, 0, 0)
+})
+```
+
+## Step 5
+
+For ``||variables:projectile||``, use a ``||Math:random||`` number for the ``vx`` velocity. Set
+the range to ``||Math:pick a random||`` between `-25` and `25`.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . . 
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    let projectile = sprites.createProjectileFromSprite(img`
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . b b . . b . . . . . . .
+. . . . . b b b b . . . . . . .
+. . . . . . . b b . . . . . . .
+. . . . . f 5 f 5 f . . . . . .
+. . . . 5 f 5 f 5 f 1 . . . . .
+. . . . 5 f 5 f 5 f 5 b . . . .
+. . . . . . 5 f 5 f 5 . . . . .
+. . . . . e . . . e . . . . . .
+. . . . e . . . . e . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+`, mySprite, Math.randomRange(-25, 25), 0)
+})
+```
+
+## Step 6
+
+Now, for the ``vy`` velocity for ``||sprites:projectile||``, set it to ``||Math:pick a random||`` number from `-25` to `25`.
+
+```spy
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . . 
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    let projectile = sprites.createProjectileFromSprite(img`
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . b b . . b . . . . . . .
+. . . . . b b b b . . . . . . .
+. . . . . . . b b . . . . . . .
+. . . . . f 5 f 5 f . . . . . .
+. . . . 5 f 5 f 5 f 1 . . . . .
+. . . . 5 f 5 f 5 f 5 b . . . .
+. . . . . . 5 f 5 f 5 . . . . .
+. . . . . e . . . e . . . . . .
+. . . . e . . . . e . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+`, mySprite, Math.randomRange(-25, 25), Math.randomRange(-25, 25))
+})
+```
+
+## Step 7 @fullscreen
+
+After the code to create the ``||variables:projectile||``, add code to set ``||sprites:lifespan||``
+to `3000`.
+
+![Adding life span](/static/tutorials/happy-flower/life-span.gif)
+
+```spy
+let projectile: Sprite = null
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . . 
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    projectile = sprites.createProjectileFromSprite(img`
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . b b . . b . . . . . . .
+. . . . . b b b b . . . . . . .
+. . . . . . . b b . . . . . . .
+. . . . . f 5 f 5 f . . . . . .
+. . . . 5 f 5 f 5 f 1 . . . . .
+. . . . 5 f 5 f 5 f 5 b . . . .
+. . . . . . 5 f 5 f 5 . . . . .
+. . . . . e . . . e . . . . . .
+. . . . e . . . . e . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+`, mySprite, Math.randomRange(-25, 25), Math.randomRange(-25, 25))
+    projectile.lifespan = 3000
+})
+```
+
+## Step 8
+
+Congratulations, your happy flower is complete! It will now send back joyful little bees. Go run your program in the simulator and see the bees fly away. Did you notice that some of the bees are fly backwards? Do you want to try something extra? If so, we can have some of the bees fly off facing in the opposite direction. Continue on with the next step.
+
+## Step 9
+
+Let's setup a condition to change the image of the bee when it flys off toward the left.
+Put in a conditional that checks ``||logic:if||`` the ``vx`` value for ``||variables:projectile||`` is
+less than `0`.
+
+```spy
+let projectile: Sprite = null
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . .
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    projectile = sprites.createProjectileFromSprite(img`
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . b b . . b . . . . . . .
+. . . . . b b b b . . . . . . .
+. . . . . . . b b . . . . . . .
+. . . . . f 5 f 5 f . . . . . .
+. . . . 5 f 5 f 5 f 1 . . . . .
+. . . . 5 f 5 f 5 f 5 b . . . .
+. . . . . . 5 f 5 f 5 . . . . .
+. . . . . e . . . e . . . . . .
+. . . . e . . . . e . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+`, mySprite, Math.randomRange(-25, 25), Math.randomRange(-25, 25))
+    projectile.lifespan = 3000
+    if (projectile.vx < 0) {
+    }
+})
+```
+
+## Step 10
+
+Inside the code block that checks ``||logic:if||`` the ``vx`` velocity is less than `0`, put in code
+to ``||images:flip horizontally||`` the ``||sprites:image||`` for ``||variables:projectile||``
+
+![Flip image of the bee](/static/tutorials/happy-flower/bee-flip.gif)
+
+```spy
+let projectile: Sprite = null
+let mySprite: Sprite = null
+scene.setBackgroundColor(9)
+mySprite = sprites.create(img`
+. . . 4 . . . . . . 2 2 . . . .
+. . . 4 4 4 3 . 3 2 2 . . . . .
+. . . . 4 e 5 5 5 e 2 . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . . 5 5 e 5 5 . . . . . .
+. . . . 3 5 5 5 5 5 3 . . . . .
+. . . . 2 e 5 5 5 e 4 . . . . .
+. . . . 2 2 3 7 3 4 4 4 . . . .
+. . . 2 2 . . 7 . . . 4 . . . .
+. . . . . . . 7 . . . . . . . .
+. . . 7 7 7 . 7 . 7 7 . . . . .
+. . . . 7 7 . 7 . 7 7 . . . . .
+. . . . . 7 7 7 7 7 . . . . . .
+. . . . . . 7 7 7 . . . . . . .
+. . . . . . . 7 . . . . . . . .
+. . . . . . . 7 . . . . . . . .
+`, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    projectile = sprites.createProjectileFromSprite(img`
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . b b . . b . . . . . . .
+. . . . . b b b b . . . . . . .
+. . . . . . . b b . . . . . . .
+. . . . . f 5 f 5 f . . . . . .
+. . . . 5 f 5 f 5 f 1 . . . . .
+. . . . 5 f 5 f 5 f 5 b . . . .
+. . . . . . 5 f 5 f 5 . . . . .
+. . . . . e . . . e . . . . . .
+. . . . e . . . . e . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . .
+`, mySprite, Math.randomRange(-25, 25), Math.randomRange(-25, 25))
+    projectile.lifespan = 3000
+    if (projectile.vx < 0) {
+        projectile.image.flipX()
+    }
+})
+```
+
+## Complete
+
+Alright, now you have bees happily flying away in both directions!

--- a/docs/tutorials/spy/happy-flower.md
+++ b/docs/tutorials/spy/happy-flower.md
@@ -13,9 +13,8 @@ Flowers make everyone around them happier, especially the bees who get nectar fr
 First, ``||scene:set background color to||`` ``light blue``. Create a new sprite called ``||variables:mySprite||``. Draw a flower as the image for the sprite.
 
 ```spy
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -40,9 +39,8 @@ mySprite = sprites.create(img`
 Put in an ``||game:on update||`` event for an interval of ``1000`` milliseconds.
 
 ```spy
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -72,9 +70,8 @@ variable to a ``||sprites:projectile sprite from||`` the ``||variables:mySprite|
 sprite. Set the velocities for both ``vx`` and ``vy`` to `0`.
 
 ```spy
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -119,9 +116,8 @@ game.onUpdateInterval(1000, function () {
 In the image editor for ``||sprites:projectile||``, make a nice little bee.
 
 ```spy
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -167,9 +163,8 @@ For ``||variables:projectile||``, use a ``||Math:random||`` number for the ``vx`
 the range to ``||Math:pick a random||`` between `-25` and `25`.
 
 ```spy
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -214,9 +209,8 @@ game.onUpdateInterval(1000, function () {
 Now, for the ``vy`` velocity for ``||sprites:projectile||``, set it to ``||Math:pick a random||`` number from `-25` to `25`.
 
 ```spy
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -262,10 +256,8 @@ After the code to create the ``||variables:projectile||``, add code to set ``||s
 to `3000`.
 
 ```spy
-let projectile: Sprite = null
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -284,7 +276,7 @@ mySprite = sprites.create(img`
 . . . . . . . 7 . . . . . . . . 
 `, SpriteKind.Player)
 game.onUpdateInterval(1000, function () {
-    projectile = sprites.createProjectileFromSprite(img`
+    let projectile = sprites.createProjectileFromSprite(img`
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
@@ -317,10 +309,8 @@ Put in a conditional that checks ``||logic:if||`` the ``vx`` value for ``||varia
 less than `0`.
 
 ```spy
-let projectile: Sprite = null
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -339,7 +329,7 @@ mySprite = sprites.create(img`
 . . . . . . . 7 . . . . . . . .
 `, SpriteKind.Player)
 game.onUpdateInterval(1000, function () {
-    projectile = sprites.createProjectileFromSprite(img`
+    let projectile = sprites.createProjectileFromSprite(img`
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
@@ -369,10 +359,8 @@ Inside the code block that checks ``||logic:if||`` the ``vx`` velocity is less t
 to ``||images:flip horizontally||`` the ``||sprites:image||`` for ``||variables:projectile||``.
 
 ```spy
-let projectile: Sprite = null
-let mySprite: Sprite = null
 scene.setBackgroundColor(9)
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 . . . 4 . . . . . . 2 2 . . . .
 . . . 4 4 4 3 . 3 2 2 . . . . .
 . . . . 4 e 5 5 5 e 2 . . . . .
@@ -391,7 +379,7 @@ mySprite = sprites.create(img`
 . . . . . . . 7 . . . . . . . .
 `, SpriteKind.Player)
 game.onUpdateInterval(1000, function () {
-    projectile = sprites.createProjectileFromSprite(img`
+    let projectile = sprites.createProjectileFromSprite(img`
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .

--- a/docs/tutorials/spy/happy-flower.md
+++ b/docs/tutorials/spy/happy-flower.md
@@ -261,8 +261,6 @@ game.onUpdateInterval(1000, function () {
 After the code to create the ``||variables:projectile||``, add code to set ``||sprites:lifespan||``
 to `3000`.
 
-![Adding life span](/static/tutorials/happy-flower/life-span.gif)
-
 ```spy
 let projectile: Sprite = null
 let mySprite: Sprite = null
@@ -368,9 +366,7 @@ game.onUpdateInterval(1000, function () {
 ## Step 10
 
 Inside the code block that checks ``||logic:if||`` the ``vx`` velocity is less than `0`, put in code
-to ``||images:flip horizontally||`` the ``||sprites:image||`` for ``||variables:projectile||``
-
-![Flip image of the bee](/static/tutorials/happy-flower/bee-flip.gif)
+to ``||images:flip horizontally||`` the ``||sprites:image||`` for ``||variables:projectile||``.
 
 ```spy
 let projectile: Sprite = null

--- a/docs/tutorials/spy/lemon-leak.md
+++ b/docs/tutorials/spy/lemon-leak.md
@@ -1,10 +1,6 @@
 # Lemon Leak
 
-### ~button /#tutorial:/tutorials/spy/lemon-leak
-
-Try this tutorial!
-
-### ~
+### @explicitHints true
 
 ## Introduction @unplugged
 

--- a/docs/tutorials/spy/lemon-leak.md
+++ b/docs/tutorials/spy/lemon-leak.md
@@ -66,15 +66,14 @@ mySprite.setFlag(SpriteFlag.StayInScreen, true)
 info.startCountdown(30)
 ```
 
-## Step 3
+## Step 3 @resetDiff
 
 Add a ``||game:on game update every||`` event and set the interval time to `1000` ms, or 1 second. In the event, create a ``||variables:projectile||`` sprite and send the ``||sprites:projectile from side||``. In the image editor for ``||variables:projectile||``, go to
 the gallery and select the strawberry.
 
 ```spy
-let projectile: Sprite = null
 game.onUpdateInterval(1000, function () {
-    projectile = sprites.createProjectileFromSide(img`
+    let projectile = sprites.createProjectileFromSide(img`
         . . . . . . . 6 . . . . . . . .
         . . . . . . 8 6 6 . . . 6 8 . .
         . . . e e e 8 8 6 6 . 6 7 8 . .
@@ -100,9 +99,8 @@ game.onUpdateInterval(1000, function () {
 Now, set both the ``vx`` and ``vy`` values for ``||variables:projectile||`` to ``||math:pick a random||`` number. Set the range for the ``||math:random||`` number from `-50` and `50`.
 
 ```spy
-let projectile: Sprite = null
 game.onUpdateInterval(1000, function () {
-    projectile = sprites.createProjectileFromSide(img`
+    let projectile = sprites.createProjectileFromSide(img`
         . . . . . . . 6 . . . . . . . .
         . . . . . . 8 6 6 . . . 6 8 . .
         . . . e e e 8 8 6 6 . 6 7 8 . .
@@ -123,12 +121,11 @@ game.onUpdateInterval(1000, function () {
 })
 ```
 
-## Step 5
+## Step 5 @resetDiff
 
 Add an ``||sprites:on overlap||`` event to your code. Set the kind which matches the ``otherSprite`` parameter to ``Projectile``. Put code into the event to ``||sprites:start spray effect||`` on ``||variables:sprite||``. Have the effect last for ``200`` ms.
 
 ```spy
-let mySprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
     sprite.startEffect(effects.spray, 200)
 })
@@ -139,7 +136,6 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, ot
 Lastly, to score hits by the strawberries on the lemon, in the ``||sprites:on overlap||`` event ``||info:change score by||`` the value of `1`.
 
 ```spy
-let mySprite: Sprite = null
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
     sprite.startEffect(effects.spray, 200)
     info.changeScoreBy(1)

--- a/docs/tutorials/spy/lemon-leak.md
+++ b/docs/tutorials/spy/lemon-leak.md
@@ -1,0 +1,157 @@
+# Lemon Leak
+
+### ~button /#tutorial:/tutorials/spy/lemon-leak
+
+Try this tutorial!
+
+### ~
+
+## Introduction @unplugged
+
+![Game animation](/static/tutorials/lemon-leak.gif)
+
+Hey, let's make a game where wild strawberries are out to attack our lemon player. The goal is to keep the lemon from losing its juice by avoiding the oncoming strawberries. The lemon will leak some of its juice when strawberries collide with it.
+
+## Step 1  @fullscreen
+
+First, ``||scene:set background color||`` to ``purple``. Create a new sprite called ``||variables:mySprite||``. Click on the image editor icon, go to the image galler, and select the lemon. Put in code to ``||controller:move mySprite||`` with the controller.
+
+![Pick the lemon image](/static/tutorials/lemon-leak/pick-a-lemon.gif)
+
+```spy
+scene.setBackgroundColor(10)
+let mySprite = sprites.create(img`
+    4 4 4 . . 4 4 4 4 4 . . . . . .
+    4 5 5 4 4 5 5 5 5 5 4 4 . . . .
+    b 4 5 5 1 5 1 1 1 5 5 5 4 . . .
+    . b 5 5 5 5 1 1 5 5 1 1 5 4 . .
+    . b d 5 5 5 5 5 5 5 5 1 1 5 4 .
+    b 4 5 5 5 5 5 5 5 5 5 5 1 5 4 .
+    c d 5 5 5 5 5 5 5 5 5 5 5 5 5 4
+    c d 4 5 5 5 5 5 5 5 5 5 5 1 5 4
+    c 4 5 5 5 d 5 5 5 5 5 5 5 5 5 4
+    c 4 d 5 4 5 d 5 5 5 5 5 5 5 5 4
+    . c 4 5 5 5 5 d d d 5 5 5 5 5 b
+    . c 4 d 5 4 5 d 4 4 d 5 5 5 4 c
+    . . c 4 4 d 4 4 4 4 4 d d 5 d c
+    . . . c 4 4 4 4 4 4 4 4 5 5 5 4
+    . . . . c c b 4 4 4 b b 4 5 4 4
+    . . . . . . c c c c c c b b 4 .
+`, SpriteKind.Player)
+controller.moveSprite(mySprite)
+```
+
+## Step 2
+
+To keep the lemon from leaving the screen, set ``||variables:mySprite||`` to ``||sprites:stay in screen||``. after that, ``||info:start a countdown||`` for `30` seconds.
+
+```spy
+scene.setBackgroundColor(10)
+let mySprite = sprites.create(img`
+    4 4 4 . . 4 4 4 4 4 . . . . . .
+    4 5 5 4 4 5 5 5 5 5 4 4 . . . .
+    b 4 5 5 1 5 1 1 1 5 5 5 4 . . .
+    . b 5 5 5 5 1 1 5 5 1 1 5 4 . .
+    . b d 5 5 5 5 5 5 5 5 1 1 5 4 .
+    b 4 5 5 5 5 5 5 5 5 5 5 1 5 4 .
+    c d 5 5 5 5 5 5 5 5 5 5 5 5 5 4
+    c d 4 5 5 5 5 5 5 5 5 5 5 1 5 4
+    c 4 5 5 5 d 5 5 5 5 5 5 5 5 5 4
+    c 4 d 5 4 5 d 5 5 5 5 5 5 5 5 4
+    . c 4 5 5 5 5 d d d 5 5 5 5 5 b
+    . c 4 d 5 4 5 d 4 4 d 5 5 5 4 c
+    . . c 4 4 d 4 4 4 4 4 d d 5 d c
+    . . . c 4 4 4 4 4 4 4 4 5 5 5 4
+    . . . . c c b 4 4 4 b b 4 5 4 4
+    . . . . . . c c c c c c b b 4 .
+`, SpriteKind.Player)
+controller.moveSprite(mySprite)
+mySprite.setFlag(SpriteFlag.StayInScreen, true)
+info.startCountdown(30)
+```
+
+## Step 3
+
+Add a ``||game:on game update every||`` event and set the interval time to `1000` ms, or 1 second. In the event, create a ``||variables:projectile||`` sprite and send the ``||sprites:projectile from side||``. In the image editor for ``||variables:projectile||``, go to
+the gallery and select the strawberry.
+
+```spy
+let projectile: Sprite = null
+game.onUpdateInterval(1000, function () {
+    projectile = sprites.createProjectileFromSide(img`
+        . . . . . . . 6 . . . . . . . .
+        . . . . . . 8 6 6 . . . 6 8 . .
+        . . . e e e 8 8 6 6 . 6 7 8 . .
+        . . e 2 2 2 2 e 8 6 6 7 6 . . .
+        . e 2 2 4 4 2 7 7 7 7 7 8 6 . .
+        . e 2 4 4 2 6 7 7 7 6 7 6 8 8 .
+        e 2 4 5 2 2 6 7 7 6 2 7 7 6 . .
+        e 2 4 4 2 2 6 7 6 2 2 6 7 7 6 .
+        e 2 4 2 2 2 6 6 2 2 2 e 7 7 6 .
+        e 2 4 2 2 4 2 2 2 4 2 2 e 7 6 .
+        e 2 4 2 2 2 2 2 2 2 2 2 e c 6 .
+        e 2 2 2 2 2 2 2 4 e 2 e e c . .
+        e e 2 e 2 2 4 2 2 e e e c . . .
+        e e e e 2 e 2 2 e e e c . . . .
+        e e e 2 e e c e c c c . . . . .
+        . c c c c c c c . . . . . . . .
+    `, 50, 100)
+})
+```
+
+## Step 4
+
+Now, set both the ``vx`` and ``vy`` values for ``||variables:projectile||`` to ``||math:pick a random||`` number. Set the range for the ``||math:random||`` number from `-50` and `50`.
+
+```spy
+let projectile: Sprite = null
+game.onUpdateInterval(1000, function () {
+    projectile = sprites.createProjectileFromSide(img`
+        . . . . . . . 6 . . . . . . . .
+        . . . . . . 8 6 6 . . . 6 8 . .
+        . . . e e e 8 8 6 6 . 6 7 8 . .
+        . . e 2 2 2 2 e 8 6 6 7 6 . . .
+        . e 2 2 4 4 2 7 7 7 7 7 8 6 . .
+        . e 2 4 4 2 6 7 7 7 6 7 6 8 8 .
+        e 2 4 5 2 2 6 7 7 6 2 7 7 6 . .
+        e 2 4 4 2 2 6 7 6 2 2 6 7 7 6 .
+        e 2 4 2 2 2 6 6 2 2 2 e 7 7 6 .
+        e 2 4 2 2 4 2 2 2 4 2 2 e 7 6 .
+        e 2 4 2 2 2 2 2 2 2 2 2 e c 6 .
+        e 2 2 2 2 2 2 2 4 e 2 e e c . .
+        e e 2 e 2 2 4 2 2 e e e c . . .
+        e e e e 2 e 2 2 e e e c . . . .
+        e e e 2 e e c e c c c . . . . .
+        . c c c c c c c . . . . . . . .
+    `, Math.randomRange(-50, 50), Math.randomRange(-50, 50))
+})
+```
+
+## Step 5
+
+Add an ``||sprites:on overlap||`` event to your code. Set the kind which matches the ``otherSprite`` parameter to ``Projectile``. Put code into the event to ``||sprites:start spray effect||`` on ``||variables:sprite||``. Have the effect last for ``200`` ms.
+
+```spy
+let mySprite: Sprite = null
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
+    sprite.startEffect(effects.spray, 200)
+})
+```
+
+## Step 6
+
+Lastly, to score hits by the strawberries on the lemon, in the ``||sprites:on overlap||`` event ``||info:change score by||`` the value of `1`.
+
+```spy
+let mySprite: Sprite = null
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
+    sprite.startEffect(effects.spray, 200)
+    info.changeScoreBy(1)
+})
+```
+
+## Complete @fullscreen
+
+That's it! Now keep moving the lemon and try not lose too much juice. Everytime a strawberry hits your lemon, it leaks some juice and the strawberry team gets points. See if you can keep the juice points down during the `30` seconds of play.
+
+![Playing Lemon Leak](/static/tutorials/lemon-leak/play-lemon-leak.jpg)


### PR DESCRIPTION
Copy and convert block-style tutorials to 'spy' tutorials - #2013.

Tutorials that seem "practical" for 'spy':

- [x] Lemon Leak
- [x] Happy Flower
- [x] Chase the Pizza

Tutorials already generalized:

- [x] Galga - works in 'spy' context as-is, without explicit hints
- [x] Paddle - works in 'spy' context as-is, without explicit hints

The remaining tutorials have very large sprite/background images or complicated tilemap structures.

**Comments**:

* Python is not currently enabled for this target. Snippets will need set to ```` ```typescript ```` to do just JS in tutorials.
* Also, ``otherActions`` seems to not work for explicit 'spy' tutorials - gets a `409` response on those. They will load if I use a direct `#tutorial:` url.

Closes #2013