### PR TITLE
Say Button 'A' in 'Barrel Dodger'

### DIFF
--- a/docs/tutorials/barrel-dodger.md
+++ b/docs/tutorials/barrel-dodger.md
@@ -187,7 +187,8 @@ tiles.placeOnTile(mySprite, tiles.getTileLocation(1, 5))
 
 ## Step 4
 
-Let's give the sprite the ability to jump when we press a button. We do this with  ``||controller:on any button pressed||``.
+Let's give the sprite the ability to jump when we press a button. We do this by moving
+the player upward in an ``||controller:on A button pressed||`` event.
 
 ```blocks
 let mySprite: Sprite = null


### PR DESCRIPTION
Change the mention of "any button" to "A button" in the Barrel Dodger tutorial.

Closes #2031