### PR TITLE
bump pxt-arcade-sim version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pxt-core": "6.1.25"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.7.18"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.7.19"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve"


### PR DESCRIPTION
pxt-arcade-sim already updated to v0.7.19, but please verify it looks right.