### PR TITLE
Add gamejam winners row to home page

### DIFF
--- a/docs/game-jam.md
+++ b/docs/game-jam.md
@@ -1,6 +1,5 @@
 # Game Jam: Garden
-
-
+Check out the winners of the 3rd Official Microsoft MakeCode Game Jam, featuring games around the theme of "gardens"! More details can be found on the [official game jam page](https://arcade.makecode.com/gamejam).
 
 ## Games
 
@@ -26,9 +25,9 @@
         "name": "Snail Hike",
         "description": "Use your puzzle-solving skills to help the snails get to the exit! ",
         "author": "SPerkins25",
-        "url": "https://arcade.makecode.com/17901-55867-81776-14236",
+        "url": "https://arcade.makecode.com/27830-69912-67539-85378",
         "cardType": "sharedExample",
-        "imageUrl": "https://pxt.azureedge.net/api/17901-55867-81776-14236/thumb"
+        "imageUrl": "https://pxt.azureedge.net/api/27830-69912-67539-85378/thumb"
     },
     {
         "name": "Garden Gnome",
@@ -66,7 +65,7 @@
         "name": "See more...",
         "description": "Check out all the entries on the official game jam page!",
         "imageUrl": "/static/gamejam/img/preview.png",
-        "url": "/gamejam"
+        "url": "https://arcade.makecode.com/gamejam"
     }
 ]
 ```

--- a/docs/game-jam.md
+++ b/docs/game-jam.md
@@ -1,0 +1,76 @@
+# Game Jam: Garden
+
+
+
+## Games
+
+```codecard
+[
+    {
+        "name": "potato",
+        "description": "Click the large potato to earn points. Spend your points to develop your garden.",
+        "author": "Reyhan",
+        "url": "https://arcade.makecode.com/42885-92487-13042-52240",
+        "cardType": "sharedExample",
+        "imageUrl": "https://pxt.azureedge.net/api/42885-92487-13042-52240/thumb"
+    },
+    {
+        "name": "Garden Crop Duster",
+        "description": "Fly a biplane over fields and bomb them with fertilizer! Don't stall or crash.",
+        "author": "jacob",
+        "url": "https://jacobcarpenter.github.io/garden-crop-duster/",
+        "cardType": "sharedExample",
+        "imageUrl": "https://pxt.azureedge.net/api/56840-41664-03413-13147/thumb"
+    },
+    {
+        "name": "Snail Hike",
+        "description": "Use your puzzle-solving skills to help the snails get to the exit! ",
+        "author": "SPerkins25",
+        "url": "https://arcade.makecode.com/17901-55867-81776-14236",
+        "cardType": "sharedExample",
+        "imageUrl": "https://pxt.azureedge.net/api/17901-55867-81776-14236/thumb"
+    },
+    {
+        "name": "Garden Gnome",
+        "description": "This garden is a dangerous place for gnomes! Help the gnome get to safety.",
+        "author": "LCProCODER",
+        "url": "https://arcade.makecode.com/33100-26828-51358-42312",
+        "cardType": "sharedExample",
+        "imageUrl": "https://pxt.azureedge.net/api/33100-26828-51358-42312/thumb"
+    },
+    {
+        "name": "Garden Puzzle",
+        "description": "Get the ladybug to the leaf, but don't let them get wet!",
+        "author": "Rishi",
+        "url": "https://arcade.makecode.com/17775-69042-79032-31406",
+        "cardType": "sharedExample",
+        "imageUrl": "https://pxt.azureedge.net/api/17775-69042-79032-31406/thumb"
+    },
+    {
+        "name": "Gazpacho!!",
+        "description": "Go to your garden, gather all the ingredients for gazpacho before time runs out!",
+        "author": "Maria",
+        "url": "https://arcade.makecode.com/66435-55863-62998-47003",
+        "cardType": "sharedExample",
+        "imageUrl": "https://pxt.azureedge.net/api/66435-55863-62998-47003/thumb"
+    },
+    {
+        "name": "HUERTO",
+        "description": "Defend your garden from pesky caterpillars! ",
+        "author": "Dylan",
+        "url": "https://arcade.makecode.com/87634-72990-40818-00211",
+        "cardType": "sharedExample",
+        "imageUrl": "https://pxt.azureedge.net/api/87634-72990-40818-00211/thumb"
+    },
+    {
+        "name": "See more...",
+        "description": "Check out all the entries on the official game jam page!",
+        "imageUrl": "/static/gamejam/img/preview.png",
+        "url": "/gamejam"
+    }
+]
+```
+
+## See Also
+
+[Game Jam Page](https://arcade.makecode.com/gamejam)

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -36,6 +36,11 @@
         "videoUrl": "/static/javascript-games/planet-putt-putt.mp4"
     },
     {
+        "name": "Game Jam",
+        "url": "/game-jam",
+        "imageUrl": "https://pxt.azureedge.net/api/42885-92487-13042-52240/thumb"
+    },
+    {
         "name": "Advanced Livestream",
         "url": "/advanced-stream",
         "imageUrl": "/static/advanced-stream/live.png"
@@ -96,6 +101,7 @@
 [Live Coding](/live-coding),
 [Blocks Games](/blocks-games),
 [JavaScript Games](/javascript-games),
+[Game Jam](/game-jam),
 [Advanced Livestream](/advanced-stream),
 [Community Games](/community),
 [Game Design Concepts](/concepts),

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -29,6 +29,7 @@
         "Live Coding": "live-coding",
         "Blocks Games": "blocks-games",
         "JavaScript Games": "javascript-games",
+        "Game Jam": "game-jam",
         "Advanced Livestream": "advanced-stream",
         "Community Games": "community",
         "Game Design Concepts": "concepts",


### PR DESCRIPTION
Should be merged in after Arcade release (Garden Crop Duster created in beta, and also requires the upgrade rules for the pxt-tilemaps extension)