### PR TITLE
[v1] port target config change for v1

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -1,8 +1,5 @@
 {
     "packages": {
-        "approvedOrgs": [
-            "Microsoft"
-        ],
         "approvedRepos": [
             "adafruit/Circuit-Playground-Character-Icons",
             "adafruit/pxt-seesaw",
@@ -20,7 +17,11 @@
             "jwunderl/pxt-status-bar",
             "microsoft/pxt-settings-blocks",
             "microsoft/arcade-sprite-data"
-        ]
+        ],
+        "upgrades": {
+            "microsoft/pxt-tilemaps": "min:v1.8.1",
+            "microsoft/arcade-sprite-data": "min:v0.0.6"
+        }
     },
     "galleries": {
         "Tutorials": "tutorials",


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/issues/2173, I looked over the backend logic and it looks like it just pulls off the major version, tries to check out the vMajor branch, and bails out to head if vMajor does not exist. Since v1 exists, it should be pulling from that instead of v0