### PR TITLE
fix upgrade rule for spritekind enums

### DIFF
--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -205,7 +205,9 @@ namespace pxt.editor {
                 block.setAttribute("type", "SpriteKindLegacy");
                 const kindValue = (block.textContent || "").trim();
                 const withoutNum = /[0-9]*([^0-9].*)/.exec(kindValue);
-                legacyKindConversions[withoutNum[1]] = kindValue;
+                if (withoutNum) {
+                    legacyKindConversions[withoutNum[1]] = kindValue;
+                }
             });
 
             pxt.U.toArray(dom.querySelectorAll("shadow[type=spritetype], block[type=spritetype]")).forEach(block => {

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -174,8 +174,47 @@ namespace pxt.editor {
          * Upgrade for enum SpriteKind -> SpriteKindLegacy
          */
         if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "0.11.20") < 0) {
+
+            /**
+             * Sometimes the getters for these omit the enum member's # improperly,
+             * so we need to map those numbers to the new values.
+             * e.g.
+             * bad:
+            <value name="kind">
+                <shadow type="spritekind">
+                    <field name="MEMBER">Cow</field>
+                </shadow>
+                <block type="spritetype">
+                    <field name="MEMBER">Player</field>
+                </block>
+            </value>
+             *
+             * good:
+            <value name="kind">
+                <shadow type="spritekind">
+                    <field name="MEMBER">7Cow</field>
+                </shadow>
+                <block type="spritetype">
+                    <field name="MEMBER">1Player</field>
+                </block>
+            </value>
+             */
+            const legacyKindConversions: pxt.Map<string> = {};
+
             pxt.U.toArray(dom.querySelectorAll("variable[type=SpriteKind]")).forEach(block => {
-                block.setAttribute("type", "SpriteKindLegacy")
+                block.setAttribute("type", "SpriteKindLegacy");
+                const kindValue = (block.textContent || "").trim();
+                const withoutNum = /[0-9]*([^0-9].*)/.exec(kindValue);
+                legacyKindConversions[withoutNum[1]] = kindValue;
+            });
+
+            pxt.U.toArray(dom.querySelectorAll("shadow[type=spritetype], block[type=spritetype]")).forEach(block => {
+                const memberField = getField(block, "MEMBER");
+                const cont = (memberField?.textContent || "").trim();
+
+                if (legacyKindConversions[cont]) {
+                    memberField.textContent = legacyKindConversions[cont];
+                }
             });
         }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2232

https://github.com/microsoft/pxt/pull/7347 fixed the block upgrade path up a bit as we were hitting exceptions depending on the blocks (it looks like it was at least whenever a project had the `Sprite.image` block. This in theory is good, as it means upgrade rules are being applied properly, but in this case the upgrade rule produced a set of blocks that was valid XML / compiled to a syntactically valid program that did not match meaning original code, and the program had 'worked' when we bailed to typescript and did the regex replaces. (I described the issue in the comment in the PR, but the issue is that the getters for SpriteKindLegacy were being set improperly getting replaced with the default value `SpriteKindLegacy.Player`)

anyways, this fixes the upgrade for legacy spritekinds in blocks I believe. Here's snowy slopes with the upgrade applied: https://arcade.makecode.com/beta#pub:_bX6g506Lt0JW

I'll defer to Abhijith on whether we would want this change for this release; I'll fix the forum game to use updated APIs in the morning either way (preferable to make it have the namespace form of spritekinds anyways, in case anyone in the future wants to mod the game)