### PR TITLE
fix common packages dep 8.1.12 -> 8.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "typescript": "^3.7.5"
     },
     "dependencies": {
-        "pxt-common-packages": "8.1.12",
+        "pxt-common-packages": "8.1.2",
         "pxt-core": "6.2.7"
     },
     "optionalDependencies": {


### PR DESCRIPTION
most recent bump is [8.1.2](https://github.com/microsoft/pxt-common-packages/commit/791e8cce1f7d6b4367b2152fafc52785039d89eb)