### PR TITLE
Add more info to 'Happy Flower' step 10

### DIFF
--- a/docs/tutorials/spy/happy-flower.md
+++ b/docs/tutorials/spy/happy-flower.md
@@ -355,8 +355,12 @@ game.onUpdateInterval(1000, function () {
 
 ## Step 10
 
-Inside the code block that checks ``||logic:if||`` the ``vx`` velocity is less than `0`, put in code
-to ``||images:flip horizontally||`` the ``||sprites:image||`` for ``||variables:projectile||``.
+Inside the code block that checks ``||logic:if||`` the ``vx`` velocity is less than
+`0`, put in code to ``||images:flip horizontally||`` the ``||sprites:image||`` for
+``||variables:projectile||``. If you are using the Toolbox code, be careful to change
+the default image given for ``||images:flip horizontally||`` to be the image property
+for the ``||variables:projectile||`` instead.
+
 
 ```spy
 scene.setBackgroundColor(9)


### PR DESCRIPTION
Step 10 of "Happy Flower" assumed that the user would know to set the image instance to `projectile.image`. However, if they are grabbing code bits from the toolbox things can get strange with the default instance attached to `flipX()`. So, an additional sentence is added to help in that case.

Closes #2258