### PR TITLE
Remove unplugged in 'Name Tag' tutorial

### DIFF
--- a/docs/tutorials/name-tag.md
+++ b/docs/tutorials/name-tag.md
@@ -277,7 +277,7 @@ scene.setBackgroundImage(img`
 effects.confetti.startScreenEffect()
 ```
 
-## Step 4 @unplugged
+## Step 4
 
 Press ``||Download||`` and transfer your name tag to your device!
 


### PR DESCRIPTION
Remove `@unplugged` from the last step in tutorial to avoid the popup annoyance.

Fixes #2060