### PR TITLE
Offline app release v1.2.7

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -41,6 +41,6 @@
         "John Park's Workshop": "john-parks-workshop"
     },
     "electronManifest": {
-        "latest": "v1.2.6"
+        "latest": "v1.2.7"
     }
 }


### PR DESCRIPTION
release version 1.2.7 to pick up https://github.com/microsoft/pxt-arcade/pull/2409

Tested that it downloads / installs on both my windows and mac devices; the only difference is in the docs, but we can test a bit more if you want as well.