### PR TITLE
Share page tweaks

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -44,7 +44,7 @@
         <iframe id="embed-frame" class="script-embed" src="/@versionsuff@--run?fullscreen=1&nofooter=1&id=@id@" sandbox="allow-popups allow-forms allow-scripts allow-same-origin"
         frameborder="0"></iframe>
         <div class="script-bookend">
-                <div id="abuse-message" class="ui tiny blue message">
+                <div id="abuse-message" class="ui tiny blue message container no-select">
                         <div class="ui grid padded">
                             <div class="abuse content">
                                 <p>
@@ -127,10 +127,10 @@
 
                     <div class="ui container horizontal mini link list">
                         <!-- <a class="ui item " href="https://makecode.com/contact " target="_blank " rel="noopener ">Contact Us</a> -->
-                        <a class="ui item " href="https://makecode.com/privacy " target="_blank " rel="noopener ">Privacy &amp; Cookies</a>
-                        <a class="ui item " href="https://makecode.com/termsofuse " target="_blank " rel="noopener "> Terms Of Use</a>
-                        <a class="ui item " href="https://makecode.com/trademarks " target="_blank " rel="noopener ">Trademarks</a>
-                        <div class="ui item ">© 2020 Microsoft</div>
+                        <a class="ui item no-select" href="https://makecode.com/privacy " target="_blank " rel="noopener ">Privacy &amp; Cookies</a>
+                        <a class="ui item no-select" href="https://makecode.com/termsofuse " target="_blank " rel="noopener "> Terms Of Use</a>
+                        <a class="ui item no-select" href="https://makecode.com/trademarks " target="_blank " rel="noopener ">Trademarks</a>
+                        <div class="ui item no-select">© 2020 Microsoft</div>
                     </div>
                 </div>
         </div>

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -20,14 +20,14 @@
         <div class="ui container">
                 <div id="page-header-wrapper">
                     <div class="page-header-item page-header-content no-grow">
-                        <h2 class="ui item header">@title@</h2>
+                        <h2 class="ui item header no-select">@title@</h2>
                     </div>
                     <div class="page-header-item show-code-toggle">
                         <button id="show-code-button" class="ui tiny default button">Show Code</button>
                         <a href="/@versionsuff@#pub:@id@" class="ui tiny button landscape only">Edit Code</a>
                     </div>
                     <div class="page-header-item no-grow">
-                        <a href="https://makecode.com/org" title="Go to Microsoft MakeCode" aria-label="Microsoft MakeCode Logo" role="menuitem" target="blank" rel="noopener" class="ui item logo organization">
+                        <a href="https://makecode.com/org" title="Go to Microsoft MakeCode" aria-label="Microsoft MakeCode Logo" role="menuitem" target="blank" rel="noopener" class="ui item logo organization no-select">
                             <img class="ui logo portrait hide" src="./static/Microsoft-logo_rgb_c-gray.png" alt="Microsoft MakeCode Logo">
                             <img class="ui mini image portrait only" src="./static/Microsoft-logo_rgb_c-gray-square.png" alt="Microsoft MakeCode Logo">
                         </a>
@@ -149,10 +149,12 @@
         showCodeButton.addEventListener("click", function() {
             // toggle game vs. code view
             if (isGame) {
+                window.pxtTickEvent('share.showcode');
                 frame.setAttribute("src", editorEmbedURL);
                 showCodeButton.textContent = "Show Game";
             }
             else {
+                window.pxtTickEvent('share.showgame');
                 frame.setAttribute("src", gameEmbedURL);
                 showCodeButton.textContent = "Show Code";
             }

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -40,8 +40,8 @@
         @BODY@
     </aside>
 
-    <div class="ui main container mainbody script-content">
-        <iframe id="embed-frame" class="script-embed" src="/@versionsuff@--run?fullscreen=1&nofooter=1&id=@id@"  sandbox="allow-popups allow-forms allow-scripts allow-same-origin"
+    <div class="ui main mainbody script-content">
+        <iframe id="embed-frame" class="script-embed" src="/@versionsuff@--run?fullscreen=1&nofooter=1&id=@id@" sandbox="allow-popups allow-forms allow-scripts allow-same-origin"
         frameborder="0"></iframe>
         <div class="script-bookend">
                 <div id="abuse-message" class="ui tiny blue message">

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -23,8 +23,8 @@
                         <h2 class="ui item header no-select">@title@</h2>
                     </div>
                     <div class="page-header-item show-code-toggle">
-                        <button id="show-code-button" class="ui tiny default button">Show Code</button>
-                        <a href="/@versionsuff@#pub:@id@" class="ui tiny button landscape only">Edit Code</a>
+                        <button id="show-code-button" class="ui mini default button">Show Code</button>
+                        <a id="editCodeButton" href="/@versionsuff@#pub:@id@" class="ui mini button landscape only">Edit Code</a>
                     </div>
                     <div class="page-header-item no-grow">
                         <a href="https://makecode.com/org" title="Go to Microsoft MakeCode" aria-label="Microsoft MakeCode Logo" role="menuitem" target="blank" rel="noopener" class="ui item logo organization no-select">
@@ -44,7 +44,7 @@
         <iframe id="embed-frame" class="script-embed" src="/@versionsuff@--run?fullscreen=1&nofooter=1&id=@id@" sandbox="allow-popups allow-forms allow-scripts allow-same-origin"
         frameborder="0"></iframe>
         <div class="script-bookend">
-                <div id="abuse-message" class="ui tiny blue message container no-select">
+                <div id="abuse-message" class="ui mini blue message container no-select">
                         <div class="ui grid padded">
                             <div class="abuse content">
                                 <p>
@@ -142,9 +142,14 @@
         var editorEmbedURL = "/@versionsuff@#sandbox:@id@";
         var gameEmbedURL = "/@versionsuff@--run?fullscreen=1&nofooter=1&id=@id@";
         var showCodeButton = document.getElementById("show-code-button");
+        var editCodeButton = document.getElementById("editCodeButton")
         var frame = document.getElementById("embed-frame");
 
         var isGame = true;
+
+        editCodeButton.addEventListener("click", function() {
+            window.pxtTickEvent('share.editcode');
+        })
 
         showCodeButton.addEventListener("click", function() {
             // toggle game vs. code view

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -148,18 +148,18 @@
         var isGame = true;
 
         editCodeButton.addEventListener("click", function() {
-            window.pxtTickEvent('share.editcode');
+            window.pxtTickEvent('share.editcode', { target: "arcade" });
         })
 
         showCodeButton.addEventListener("click", function() {
             // toggle game vs. code view
             if (isGame) {
-                window.pxtTickEvent('share.showcode');
+                window.pxtTickEvent('share.showcode', { target: "arcade" });
                 frame.setAttribute("src", editorEmbedURL);
                 showCodeButton.textContent = "Show Game";
             }
             else {
-                window.pxtTickEvent('share.showgame');
+                window.pxtTickEvent('share.showgame', { target: "arcade" });
                 frame.setAttribute("src", gameEmbedURL);
                 showCodeButton.textContent = "Show Code";
             }

--- a/docs/static/script-page.css
+++ b/docs/static/script-page.css
@@ -6,7 +6,7 @@ body#root {
 
 body#root.share-page {
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    background-color: #92f9ff;
+    background-color: #fdf3e0;
 }
 
 body#root.share-page #pagemenu .ui.header {

--- a/docs/static/script-page.css
+++ b/docs/static/script-page.css
@@ -6,6 +6,7 @@ body#root {
 
 body#root.share-page {
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    background-color: #92f9ff;
 }
 
 body#root.share-page #pagemenu .ui.header {

--- a/docs/static/script-page.css
+++ b/docs/static/script-page.css
@@ -71,7 +71,7 @@ body#root.share-page .ui.mini.image.mclogo {
     flex-grow: 0;
 }
 
-.ui.container.script-content {
+.ui.script-content {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
@@ -113,7 +113,7 @@ body#root.share-page .ui.mini.image.mclogo {
     padding: 0.5rem;
 }
 @media only screen and (max-width: 1144px) {
-    .ui.container.mainbody {
+    .ui.mainbody {
         padding-left: 0!important;
         padding-right: 0!important;
         margin-left: auto!important;
@@ -127,13 +127,13 @@ body#root.share-page .ui.mini.image.mclogo {
         height: 2.8rem;
         min-height: 2.8rem !important;
     }
-    .ui.container.mainbody, .page-header .ui.container {
+    .ui.mainbody, .page-header .ui.script-content {
         margin: 0 !important;
     }
 }
 
 @media only screen and (min-width: 769px) {
-    .ui.container.mainbody, .page-header .ui.container {
+    .ui.mainbody, .page-header .ui.script-content {
         padding-left: 1em;
         padding-right: 1em;
     }


### PR DESCRIPTION
Various small optimization to pretify the shared script page:
- [x] use a bluish color backround
- [x] stretch simulator to full width (don't use container)
- [x] small font for disclaimer/buttons (same as copyright)
- [x] disable user select (``.no-select`` class) on most UI elements to remove pesky selection on iphone
- [x] ticks for buttons

Tested windows Chrome/Edge/FF. Needs to go in the arcade stable branch?

1366x768
![image](https://user-images.githubusercontent.com/4175913/100990153-6fff2480-3506-11eb-9757-1d30fc8c4430.png)
1920x1080
![image](https://user-images.githubusercontent.com/4175913/100990201-7c837d00-3506-11eb-9fa3-fd9e46f37c65.png)

mobile
![image](https://user-images.githubusercontent.com/4175913/100989841-1dbe0380-3506-11eb-9a58-5aa1f561ed66.png)
![image](https://user-images.githubusercontent.com/4175913/100989865-244c7b00-3506-11eb-96a9-dfdc570b73da.png)
Unclear why ipad sim does not resize to full width...
![image](https://user-images.githubusercontent.com/4175913/100989896-2c0c1f80-3506-11eb-8b90-d72360955326.png)
![image](https://user-images.githubusercontent.com/4175913/100989972-42b27680-3506-11eb-8440-32b78621902e.png)
![image](https://user-images.githubusercontent.com/4175913/100990013-4ba34800-3506-11eb-81fc-016be407071d.png)




