### PR TITLE
Fix kitronik arcade offline app deploy

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -110,7 +110,7 @@
     ],
     "compile": {
         "useUF2": true,
-        "deployDrives": "(ARCADE|PY|FTHR840BOOT)",
+        "deployDrives": "(ARCADE|PY|FTHR840BOOT|ARCD)",
         "deployFileMarker": "INFO_UF2.TXT",
         "driveName": "ARCADE",
         "floatingPoint": true,


### PR DESCRIPTION
re: https://forum.makecode.com/t/makecode-arcade-offline-pairing/5022/6, looks like they named their drives something novel and so we're not auto deploying to them.

For reference, this field is used in https://github.com/microsoft/pxt-electron/blob/master/src/deploy.ts#L90 to list out the drives / try to copy over the file to any matches 