### PR TITLE
Bumping arcade sim version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pxt-core": "6.7.4"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.7.20"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.8.1"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve"


### PR DESCRIPTION
The sim was broken by the latest updates to pxt-common-packages and pxt-core and i think it got missed in this commit:

https://github.com/microsoft/pxt-arcade/commit/46042e8020ca487b0a8aae38172b56c9ae626ff5