### PR TITLE
fix sprites not appearing on spacejam tutorial

### DIFF
--- a/docs/tutorials/chase-the-basketball.md
+++ b/docs/tutorials/chase-the-basketball.md
@@ -1513,5 +1513,5 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Basketball, function (sprite, ot
 ```
 
 ```package
-spacejam=github:microsoft/chase-the-basketball-sprites-extension#v0.0.2
+space-jam-sprites=github:microsoft/chase-the-basketball-sprites-extension#v0.0.2
 ```


### PR DESCRIPTION
This should fix the issue we are seeing with the Space Jam tutorial where the Space Jam sprites aren't appearing on subsequent reloads.

Another work around for this is to always use incognito for each session.

This is a work around for an issue in microsoft/pxt stable6.2.
Here is where we chose which symbols to cache for a package:
https://github.com/microsoft/pxt/blob/stable6.2/webapp/src/compiler.ts#L669
notice we're comparing the symbol's `.pkg` field to the `name` variable.
The name var comes from the package config, e.g. "space-jam-sprites" in this case
The .pkg field comes from:
https://github.com/microsoft/pxt/blob/stable6.2/webapp/src/compiler.ts#L623
which is the directory name e.g. "spacejam".
So none of the symbols are matching and thus we're storing empty apis in the cache for the space jam package.

This might be fixed in master since the api check is now:
https://github.com/microsoft/pxt/blob/master/webapp/src/compiler.ts#L707
which compares the .pkg field (still a dirname) to the getPkgId() value
