### PR TITLE
Dev only: Set arcade VS Code workspace colors

### DIFF
--- a/arcade.code-workspace
+++ b/arcade.code-workspace
@@ -12,5 +12,12 @@
 		{
 			"path": "."
 		}
-	]
+	],
+	"settings": {
+		"workbench.colorCustomizations": {
+			"activityBar.background": "#00323b",
+			"activityBar.foreground": "#fcc96b"
+		}
+	}
+
 }


### PR DESCRIPTION
This is a development environment only change and has **no user impact**.

This sets a side bar color for the arcade workspace. this helps distinguish multiple VS Code windows at a glance.

Example:
<img width="544" alt="Screen Shot 2021-01-11 at 1 19 49 PM" src="https://user-images.githubusercontent.com/6453828/104239669-bf8f1500-540f-11eb-8890-29544180f983.png">
