### PR TITLE
Changing arcade icon link to makecode.com

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -440,7 +440,7 @@
         }        
     },
     "appTheme": {
-        "logoUrl": "https://github.com/microsoft/pxt-arcade",
+        "logoUrl": "https://makecode.com/org",
         "logo": "./static/logo.svg",
         "docsLogo": "./static/logo.svg",
         "cardLogo": "./static/logo.svg",


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2629
For now point to about in microsoft.com/makecode.