### PR TITLE
Revert "Dev only: Set arcade VS Code workspace colors"

### DIFF
--- a/arcade.code-workspace
+++ b/arcade.code-workspace
@@ -12,12 +12,5 @@
 		{
 			"path": "."
 		}
-	],
-	"settings": {
-		"workbench.colorCustomizations": {
-			"activityBar.background": "#00323b",
-			"activityBar.foreground": "#fcc96b"
-		}
-	}
-
+	]
 }


### PR DESCRIPTION
Reverts microsoft/pxt-arcade#2839