### PR TITLE
add page linking to game jams

### DIFF
--- a/docs/gamejams.md
+++ b/docs/gamejams.md
@@ -1,0 +1,34 @@
+# Game Jams
+
+Past game jams that have been held in Arcade
+
+## Game Jams
+
+```codecard
+[
+    {
+        "name": "Garden Jam",
+        "description": "Garden themed jam hosted in Arcade",
+        "url": "/gamejam/garden",
+        "imageUrl": "/static/gamejam/jams/garden/assets/garden.gif"
+    },
+    {
+        "name": "Traffic Jam",
+        "description": "Traffic themed jam hosted in Arcade",
+        "url": "/gamejam/traffic",
+        "imageUrl": "/static/gamejam/jams/traffic/assets/traffic.gif"
+    },
+    {
+        "name": "Ocean Jam",
+        "description": "Ocean themed jam hosted in Arcade",
+        "url": "/gamejam/ocean",
+        "imageUrl": "/static/gamejam/jams/ocean/assets/preview.png"
+    }
+]
+```
+
+## See also
+
+[Garden Jam](/gamejam/garden),
+[Traffic Jam](/gamejam/traffic),
+[Ocean Jam](/gamejam/ocean)


### PR DESCRIPTION
Adds a quick ref page to link to the previous game jams / results.

![image](https://user-images.githubusercontent.com/5615930/106513989-8aaf3480-6488-11eb-886b-902b3e8751c3.png)
