### PR TITLE
Bump codal on F4 to 1.3.0 - fixes sound choppines

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -262,7 +262,7 @@
                 "codalTarget": {
                     "name": "codal-big-brainpad",
                     "url": "https://github.com/lancaster-university/codal-big-brainpad",
-                    "branch": "v1.2.0",
+                    "branch": "v1.3.0",
                     "type": "git"
                 },
                 "codalBinary": "STM32",


### PR DESCRIPTION
This fixes sound especially when using the big parallel screen