### PR TITLE
Link in thumb image for 'Fishy Fishy' game

### DIFF
--- a/docs/game-jam.md
+++ b/docs/game-jam.md
@@ -58,7 +58,7 @@ Check out the winners of the 4th Official Microsoft MakeCode Game Jam, featuring
 * author: UnsignedArduino
 * url: https://unsignedarduino.github.io/Fishy-Fishy-Cross-my-Ocean/
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/63434-59192-93007-07962/thumb
+* imageUrl: https://raw.githubusercontent.com/UnsignedArduino/Fishy-Fishy-Cross-my-Ocean/master/.github/makecode/thumb.png
 ---
 * name: Caballito Saltarin
 * description: Dodge pollution and plastic waste while trying to get to the end in this lovely platformer.


### PR DESCRIPTION
Thumb images aren't generated for GitHub based projects. I had the game author add an image to their repo: https://github.com/UnsignedArduino/Fishy-Fishy-Cross-my-Ocean/issues/2.

Not sure if this is the best way to do this but it will fill the "gap" for now.

**Before:**

![image](https://user-images.githubusercontent.com/27789908/109071020-17c06480-76a8-11eb-9e27-08eb720e4300.png)

**After:**

![image](https://user-images.githubusercontent.com/27789908/109071148-34f53300-76a8-11eb-8b7a-98df837bda2d.png)

Fixes #3044
