### PR TITLE
Update link for Ovobot Xtron

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -49,10 +49,10 @@ These boards run MakeCode Arcade games. Choose a board to find out more about it
         "variant": "hw---stm32f401"
     },
     {
-        "name": "Ovobot Xtron",
+        "name": "Ovobot Xtron Pro",
         "description": "A programmable microcomputer that can be used for making MakeCode Arcade games.",
         "imageUrl": "/static/hardware/xtron.jpg",
-        "url": "https://www.ovobot.cn/product/detail/xtron/",
+        "url": "https://www.ovobot.cc/en/product/detail/xtron-pro/",
         "variant": "hw---stm32f401"
     },
     {


### PR DESCRIPTION
New link and product page for Ovobot Xtron:

https://www.ovobot.cc/en/product/detail/xtron-pro/

Fixes: #3177