### PR TITLE
Adding beginner skillmap path alias

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -49,7 +49,10 @@
         ]
     },
     "skillMap": {
-        "defaultPath": "github:microsoft/pxt-skillmap-sample/skillmap.md"
+        "defaultPath": "github:microsoft/pxt-skillmap-sample/skillmap.md",
+        "pathAliases": {
+            "beginner": "docs:/skillmap/beginner-skillmap-2"
+        }
     },
     "galleries": {
         "Tutorials": "tutorials",


### PR DESCRIPTION
Adding a path alias to test https://github.com/microsoft/pxt/pull/7971

This maps this URL:
https://arcade.makecode.com/beta--skillmap#beginner

to this URL:
https://arcade.makecode.com/beta--skillmap#docs:/skillmap/beginner-skillmap-2

@kiki-lee is this the right skillmap to point to? We can change it before we "officially" release it, this is really just for testing.