### PR TITLE
[stable1.3] Bump pxt-core to 6.8.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "8.4.11",
-        "pxt-core": "6.8.37",
+        "pxt-core": "6.8.38",
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.8.3"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Pulls in the change hardcoding the default URL for the skill map