### PR TITLE
Add pxt-skillmap-sample as an alternate source for the intermediate map

### DIFF
--- a/docs/skillmap/intermediate-skillmap.md
+++ b/docs/skillmap/intermediate-skillmap.md
@@ -2,7 +2,7 @@
 * name: Game Maker Guide
 * description: Level up your game making skills by completing the tutorials in this guide.
 * infoUrl: skillmap/educator-info/int-map-info
-
+* alternatesources: github:https://github.com/microsoft/pxt-skillmap-sample/skillmap.md
 
 ## interface
 * name: Learn to use MakeCode Arcade


### PR DESCRIPTION
Add the alternate source url for migrating user progress from the old (github) game maker guide to the new docs one.