### PR TITLE
Fix share page for release

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -136,7 +136,7 @@
         @body@
     </div>
 
-    <script type="text/javascript" src="/---embed"></script>
+    <script type="text/javascript" src="/beta---embed"></script>
     <script>
         (function() {
             var editorEmbedURL = "/@versionsuff@#sandbox:@id@";
@@ -228,11 +228,14 @@
             });
 
             function prebuildSimulator(container) {
+                // This line gets patched up by the cloud
+                var pxtConfig = null;
+
                 var sims = document.createElement("div");
                 sims.className = "sim-embed";
                 var simframeWrapper = document.createElement("div");
                 simframeWrapper.className = "simframe ui embed";
-                var simUrl = "https://trg-arcade.userpxt.io/---simulator";
+                var simUrl = "https://trg-arcade.userpxt.io/beta---simulator";
                 var emptySim = createIFrame(simUrl);
                 emptySim.className = "grayscale";
                 // unused, satisfying pxtsim/simdriver.ts#setFrameState
@@ -259,7 +262,7 @@
                             builtJsInfo: builtSimJS,
                         };
                         console.log('simulating script');
-                        pxt.runner.simulateAsync(container, options).done(function(built) {
+                        pxt.runner.simulateAsync(container, options).then(function(built) {
                             if (!builtSimJS)
                                 builtSimJSPromise = Promise.resolve(built);
                             console.log('simulator started...');

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -41,7 +41,9 @@
     </aside>
 
     <div class="ui main mainbody script-content">
-        <div id="embed-frame"></div>
+        <div id="embed-frame">
+            <div id="loader" style="text-align:center;margin:20% auto;font-family:monospace;font-size:25px;">loading...</div>
+        </div>
         <div class="script-bookend">
             <div id="abuse-message" class="ui mini blue message container no-select">
                 <div class="ui grid padded">
@@ -137,6 +139,7 @@
     </div>
 
     <script type="text/javascript" src="/beta---embed"></script>
+    <!-- <script type="text/javascript" src="/embed.js"></script> -->
     <script>
         (function() {
             var editorEmbedURL = "/@versionsuff@#sandbox:@id@";
@@ -158,7 +161,7 @@
                     });
             }
 
-            prebuildSimulator(embedContainer);
+            // prebuildSimulator(embedContainer);
             ksRunnerReady(function() {
                 runSimulator(embedContainer);
             });
@@ -233,8 +236,7 @@
                 var simframeWrapper = document.createElement("div");
                 simframeWrapper.className = "simframe ui embed";
                 window.pxtConfig = { simUrl: "https://trg-arcade.userpxt.io/beta---simulator" };
-                var simUrl = window.pxtConfig.simUrl;
-                var emptySim = createIFrame(simUrl);
+                var emptySim = createIFrame(window.pxtConfig.simUrl);
                 emptySim.className = "grayscale";
                 // unused, satisfying pxtsim/simdriver.ts#setFrameState
                 var icon = document.createElement("div");
@@ -260,7 +262,10 @@
                             builtJsInfo: builtSimJS,
                         };
                         console.log('simulating script');
+                        window.pxtConfig = { simUrl: window.pxt.webConfig.simUrl };
                         pxt.runner.simulateAsync(container, options).then(function(built) {
+                            var loader = document.getElementById("loader")
+                            if (loader) loader.remove();
                             if (!builtSimJS)
                                 builtSimJSPromise = Promise.resolve(built);
                             console.log('simulator started...');

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -228,9 +228,6 @@
             });
 
             function prebuildSimulator(container) {
-                // This line gets patched up by the cloud
-                var pxtConfig = null;
-
                 var sims = document.createElement("div");
                 sims.className = "sim-embed";
                 var simframeWrapper = document.createElement("div");

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -232,7 +232,8 @@
                 sims.className = "sim-embed";
                 var simframeWrapper = document.createElement("div");
                 simframeWrapper.className = "simframe ui embed";
-                var emptySim = createIFrame("https://trg-arcade.userpxt.io/---simulator")
+                var simUrl = "https://trg-arcade.userpxt.io/---simulator";
+                var emptySim = createIFrame(simUrl);
                 emptySim.className = "grayscale";
                 // unused, satisfying pxtsim/simdriver.ts#setFrameState
                 var icon = document.createElement("div");

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -232,7 +232,8 @@
                 sims.className = "sim-embed";
                 var simframeWrapper = document.createElement("div");
                 simframeWrapper.className = "simframe ui embed";
-                var simUrl = "https://trg-arcade.userpxt.io/beta---simulator";
+                window.pxtConfig = { simUrl: "https://trg-arcade.userpxt.io/beta---simulator" };
+                var simUrl = window.pxtConfig.simUrl;
                 var emptySim = createIFrame(simUrl);
                 emptySim.className = "grayscale";
                 // unused, satisfying pxtsim/simdriver.ts#setFrameState

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -138,7 +138,7 @@
         @body@
     </div>
 
-    <script type="text/javascript" src="/beta---embed"></script>
+    <script type="text/javascript" src="/---embed"></script>
     <!-- <script type="text/javascript" src="/embed.js"></script> -->
     <script>
         (function() {

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -232,7 +232,7 @@
                 sims.className = "sim-embed";
                 var simframeWrapper = document.createElement("div");
                 simframeWrapper.className = "simframe ui embed";
-                var emptySim = createIFrame("/---simulator")
+                var emptySim = createIFrame("https://trg-arcade.userpxt.io/---simulator")
                 emptySim.className = "grayscale";
                 // unused, satisfying pxtsim/simdriver.ts#setFrameState
                 var icon = document.createElement("div");

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -235,8 +235,7 @@
                 sims.className = "sim-embed";
                 var simframeWrapper = document.createElement("div");
                 simframeWrapper.className = "simframe ui embed";
-                window.pxtConfig = { simUrl: "https://trg-arcade.userpxt.io/beta---simulator" };
-                var emptySim = createIFrame(window.pxtConfig.simUrl);
+                var emptySim = createIFrame("/sim/simulator.html")
                 emptySim.className = "grayscale";
                 // unused, satisfying pxtsim/simdriver.ts#setFrameState
                 var icon = document.createElement("div");
@@ -264,7 +263,7 @@
                         console.log('simulating script');
                         window.pxtConfig = { simUrl: window.pxt.webConfig.simUrl };
                         pxt.runner.simulateAsync(container, options).then(function(built) {
-                            var loader = document.getElementById("loader")
+                            var loader = document.getElementById("loader");
                             if (loader) loader.remove();
                             if (!builtSimJS)
                                 builtSimJSPromise = Promise.resolve(built);

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -136,7 +136,7 @@
         @body@
     </div>
 
-    <script type="text/javascript" src="/embed.js"></script>
+    <script type="text/javascript" src="/---embed"></script>
     <script>
         (function() {
             var editorEmbedURL = "/@versionsuff@#sandbox:@id@";
@@ -232,7 +232,7 @@
                 sims.className = "sim-embed";
                 var simframeWrapper = document.createElement("div");
                 simframeWrapper.className = "simframe ui embed";
-                var emptySim = createIFrame("/sim/simulator.html")
+                var emptySim = createIFrame("/---simulator")
                 emptySim.className = "grayscale";
                 // unused, satisfying pxtsim/simdriver.ts#setFrameState
                 var icon = document.createElement("div");

--- a/docs/static/script-page.css
+++ b/docs/static/script-page.css
@@ -211,8 +211,8 @@ div.simframe {
     padding-bottom: 0 !important;
 }
 
-div.simframe > iframe {
+div.simframe.ui.embed > iframe {
     position: relative !important;
     width: 100%;
-    height: 100%;
+    height: 99%;
 }


### PR DESCRIPTION
Fix the issues it ran into last time; here's it running on staging: https://arcade.staging.pxt.io/64715-80137-62241-32687 (theres a `HEAD_OVERRIDE` field set in staging at the moment making it reference this branch for docfiles, I'll remove that later today so it points to index-ref like normal). Main thing this change does is removes= one blocking web request (effectively just flattening the sim run code into the page so we don't have to wait to fetch that too). It also that it keeps the built js info in memory so if you switch to 'show code' and back it will be instant like Asphodel -- this is super helpful for me at least because I do that ALL the time when looking at forum games.

(I disabled the bit where it was preloading the simulator grayed out instead of showing the loading text for now, that requires fixes in pxt & possible pxt-backend from the looks of it. Will see how easy that is later ~)

![instant](https://user-images.githubusercontent.com/5615930/111817330-20691c80-889b-11eb-8917-478aacb39dd5.gif)
