### PR TITLE
Fix share page sizing on mobile safari

### DIFF
--- a/docs/static/script-page.css
+++ b/docs/static/script-page.css
@@ -214,5 +214,15 @@ div.simframe {
 div.simframe.ui.embed > iframe {
     position: relative !important;
     width: 100%;
-    height: 99%;
+}
+
+/* ios safari -- fix height */
+div#embed-frame {
+    display: flex;
+    align-items: stretch;
+}
+div.simframe.ui.embed,
+#embed-frame iframe.sim-embed {
+    display: flex;
+    height: auto !important;
 }


### PR DESCRIPTION
https://forum.makecode.com/t/game-controller-not-showing-up-on-mobile/6896

fix sizing for share page on safari; safari is very "by the book" on 100% height resolution (each parent element above must have height explicitly defined), so switch to flex to keep height consistent. Tested on safari / chrome / firefox / mobile safari / mobile android (chrome)