### PR TITLE
Update targetconfig.json

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -32,6 +32,7 @@
             "microsoft/arcade-timers",
             "microsoft/arcade-text",
             "microsoft/pxt-tilemaps",
+            "mr-coxall/turtle-logo",
             "microsoft/arcade-storytelling"
         ],
         "upgrades": {


### PR DESCRIPTION
Forgot to add in the Turtle Logo extension to the list the use sees when they select the extension menu. The extension is already approved, just not visible to use right away.