### PR TITLE
fix parsing for share page in edge17

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -226,7 +226,7 @@
                             'simulator.user.tick',
                             data,
                         );
-                    } catch { /** failed to parse tick from game **/ }
+                    } catch (e) { /** failed to parse tick from game **/ }
                 }
             });
 


### PR DESCRIPTION
I went through a bunch of browsers on browserstack for the share page to make sure there weren't any other regressions and noticed this has been broken on old edge for a while (~4 months or so, since the asphodel ticks). Sounds like omitting this is technically a feature of es2019, but most browsers started supporting it long ago so only old edge hits it. Might as well fix anyway for cleanliness / we'll have another bug patch this week we can include it in anyways.