### PR TITLE
Remove allowcodecarryover flags from tutorial markdown

### DIFF
--- a/docs/skillmap/collector/collector1.md
+++ b/docs/skillmap/collector/collector1.md
@@ -47,9 +47,6 @@ forever(function () {
 
 
 ## Intro @unplugged
-* allowcodecarryover: false
-
-
 
 Ready to give your **W,A,S,D** keys a workout? 
 

--- a/docs/skillmap/interface/activity1.md
+++ b/docs/skillmap/interface/activity1.md
@@ -31,9 +31,6 @@ game.onUpdateInterval(5000, function () {
 ### @explicitHints true
 
 ## Introduction @unplugged
-* allowcodecarryover: false
-
-
 
 ![Psyched Monkey](/static/skillmap/interface/monkey.png "Psyched Monkey is Ready!" )
 

--- a/docs/skillmap/platformer/activity1.md
+++ b/docs/skillmap/platformer/activity1.md
@@ -74,9 +74,6 @@ tiles.setTilemap(tilemap`level`)
 ```
 
 ## Welcome @unplugged
-* allowcodecarryover: false
-
-
 
 Now let's take a look at the [__*sidescrolling*__](#scrolld "games that are viewed from the side, with most of the action happening horizontally") 
 [__*platformer*__](#plat "games that rely on jump and run as their main mechanic").  

--- a/docs/skillmap/puzzle/puzzle1.md
+++ b/docs/skillmap/puzzle/puzzle1.md
@@ -67,9 +67,6 @@ NewRound()
 
 
 ## Welcome @unplugged
-* allowcodecarryover: false
-
-
 
 We've made stories, clicker games, and collector games...now it's time to learn the secrets behind puzzle games!
 

--- a/docs/skillmap/space/activity1.md
+++ b/docs/skillmap/space/activity1.md
@@ -2,9 +2,6 @@
 
 
 ## Introduction @unplugged
-* allowcodecarryover: false
-
-
 
 ** Let's explore the depths of space! **
 

--- a/docs/skillmap/story/story1.md
+++ b/docs/skillmap/story/story1.md
@@ -269,9 +269,6 @@ music.playMelody("G B A G C5 B A B ", 120)
 
 
 ## Intro @unplugged
-* allowcodecarryover: false
-
-
 
 Are you ready to make greeting cards for your friends and family?
 


### PR DESCRIPTION
Removing these, since the property only needs to be set in the skillmap markdown! Going to merge it in now, as the space and platformer tutorials are being linked in the live skillmap