### PR TITLE
Cache used blocks from space and platformer tutorials

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -108,6 +108,10 @@
         "libs/color-coded-tilemap",
         "libs/template"
     ],
+    "cacheusedblocksdirs": [
+        "skillmap/space",
+        "skillmap/platformer"
+    ],
     "compile": {
         "useUF2": true,
         "deployDrives": "(ARCADE|PY|FTHR840BOOT|ARCD)",


### PR DESCRIPTION
turning on the tutorial info caching for these since the content seems relatively stable