### PR TITLE
Remove flyoutOnly flag for zookeeper tutorials

### DIFF
--- a/docs/skillmap/zoo/zoo1.md
+++ b/docs/skillmap/zoo/zoo1.md
@@ -1,4 +1,3 @@
-### @flyoutOnly true
 
 # First Day
 

--- a/docs/skillmap/zoo/zoo2.md
+++ b/docs/skillmap/zoo/zoo2.md
@@ -1,4 +1,3 @@
-### @flyoutOnly true
 
 # First Exhibit: By Land
 

--- a/docs/skillmap/zoo/zoo2a.md
+++ b/docs/skillmap/zoo/zoo2a.md
@@ -1,4 +1,3 @@
-### @flyoutOnly true
 
 # First Exhibit: By Sea
 

--- a/docs/skillmap/zoo/zoo3.md
+++ b/docs/skillmap/zoo/zoo3.md
@@ -1,5 +1,3 @@
-### @flyoutOnly true
-
 
 # Penguins!
 

--- a/docs/skillmap/zoo/zoo4.md
+++ b/docs/skillmap/zoo/zoo4.md
@@ -1,4 +1,3 @@
-### @flyoutOnly true
 
 # Feed the Panda
 

--- a/docs/skillmap/zoo/zoo5.md
+++ b/docs/skillmap/zoo/zoo5.md
@@ -1,4 +1,3 @@
-### @flyoutOnly true
 
 # Quail Hatching
 


### PR DESCRIPTION
i think there's some instability with the flyoutOnly rendering and the skillmap, since flyoutOnly requires reloading the toolbox and the skillmap has it's own, separate, project loading flow