### PR TITLE
Invalidate tutorial used blocks cache for Space Explorer activity 4

### DIFF
--- a/docs/skillmap/space/activity4.md
+++ b/docs/skillmap/space/activity4.md
@@ -389,7 +389,7 @@ game.onUpdateInterval(500, function () {
 ```
 
 ```ghost
-statusbar.positionDirection(CollisionDirection.Bottom)
+statusbar.positionDirection(CollisionDirection.Top)
 ```
 
 ```package


### PR DESCRIPTION
this tutorial was loading without the status bars previously, and we would have cached the incorrect list of used blocks. small code change should invalidate that cache and cause the list to be re-parsed