### PR TITLE
make a few of the builtin exts searchOnly

### DIFF
--- a/libs/color/pxt.json
+++ b/libs/color/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/color"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/color",
+    "searchOnly": true
 }

--- a/libs/keyboard/pxt.json
+++ b/libs/keyboard/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/keyboard"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/keyboard",
+    "searchOnly": true
 }

--- a/libs/mouse/pxt.json
+++ b/libs/mouse/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mouse"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mouse",
+    "searchOnly": true
 }

--- a/libs/palette/pxt.json
+++ b/libs/palette/pxt.json
@@ -1,4 +1,5 @@
 {
     "additionalFilePath": "../../node_modules/pxt-common-packages/libs/palette",
+    "searchOnly": true,
     "weight": 75
 }

--- a/libs/radio/pxt.json
+++ b/libs/radio/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/radio"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/radio",
+    "searchOnly": true
 }

--- a/libs/storyboard/pxt.json
+++ b/libs/storyboard/pxt.json
@@ -1,4 +1,5 @@
 {
     "additionalFilePath": "../../node_modules/pxt-common-packages/libs/storyboard",
+    "searchOnly": true,
     "weight": 81
 }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2391

These are the ones that stood out to me as 'unlikely to be what the user expects' or that are questionably functional

* mouse and keyboard: these are for making hardware devices act as mouse and keyboard, several times have had people on the forums confused / trying to use it to read input
* color and palette; these are more underlying libraries / mainly for compat with adafruit
* radio; questionable whether things work
* storyboard; js only and a bit confusing