### PR TITLE
Set current default parms for tutorial hints

### DIFF
--- a/docs/concepts/sunday-drive.md
+++ b/docs/concepts/sunday-drive.md
@@ -50,13 +50,13 @@ game.onUpdateInterval(1000, function () {
 . . f f f f f e e f f f f f e .
 . . . f f f . . . . f f f f . .
 . . . . . . . . . . . . . . . .
-`, 50, 100)
+`, 50, 50)
 })
 ```
 
 ## Step 4 @fullscreen
 
-In the ``||sprites:projectile||``, set the ``||sprites:vy||`` to 0, so that the cars drive **only** to the right.
+In the ``||sprites:projectile||``, set the ``||sprites:vy||`` to `0`, so that the cars drive **only** to the right.
 
 ```blocks
 let projectile: Sprite = null;
@@ -115,7 +115,7 @@ game.onUpdateInterval(1000, function () {
 
 Find ``||math:pick random 0 to 10||`` in ``||math:Math||``, and replace the 0 in ``||sprites:set projectile y to 0||`` with the it.
 
-This will place the ``||variables:projectile||`` in a random ``||sprites:y||`` position between 0 and 10.
+This will place the ``||variables:projectile||`` in a random ``||sprites:y||`` position between `0` and `10`.
 
 ```blocks
 let projectile: Sprite = null;

--- a/docs/concepts/throw-a-bone.md
+++ b/docs/concepts/throw-a-bone.md
@@ -91,7 +91,7 @@ let projectile = sprites.createProjectileFromSprite(img`
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
-`, mySprite, 50, 100)
+`, mySprite, 50, 50)
 ```
 
 ## Step 3 @fullscreen
@@ -142,12 +142,12 @@ let projectile = sprites.createProjectileFromSprite(img`
 . . . . 1 1 . . . . . . . . . .
 . . . . . . . . . . . . . . . .
 . . . . . . . . . . . . . . . .
-`, mySprite, 50, 100)
+`, mySprite, 50, 50)
 ```
 
 ## Step 4 @fullscreen
 
-In ``||sprites:projectile||``, change ``||sprites:vy||`` from `100` to `-15` so that it moves **upwards** instead of **downwards**.
+In ``||sprites:projectile||``, change ``||sprites:vy||`` from `50` to `-15` so that it moves **upwards** instead of **downwards**.
 
 ```blocks
 let mySprite = sprites.create(img`

--- a/docs/tutorials/lemon-leak.md
+++ b/docs/tutorials/lemon-leak.md
@@ -94,7 +94,7 @@ game.onUpdateInterval(1000, function () {
         e e e e 2 e 2 2 e e e c . . . .
         e e e 2 e e c e c c c . . . . .
         . c c c c c c c . . . . . . . .
-    `, 50, 100)
+    `, 50, 50)
 })
 ```
 


### PR DESCRIPTION
A few tutorials had nonconforming default parameters for **sprites.createProjectileFromSide(image, 50, 50)**.

Fixes #2049