### PR TITLE
Remove 'Furry Jump and Run'

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -324,15 +324,6 @@ Games submitted by the MakeCode community.
         "description": ""
     },
     {
-        "url": "https://forum.makecode.com/t/furry-my-favourite-jump-and-run/2016",
-        "imageUrl": "/static/discourse/49159-47146-69570-35115.png",
-        "author": "Napomex",
-        "cardType": "forumUrl",
-        "name": "Furry my favourite jump and run",
-        "description": "",
-        "largeImageUrl": "/static/discourse/49159-47146-69570-35115.gif"
-    },
-    {
         "name": "Add Game",
         "description": "Are you looking to contribute your own game? These instructions will explain how to submit your game for the chance to appear in this carousel.",
         "imageUrl": "/static/community/add-game.png",


### PR DESCRIPTION
The `README.md` appears in the sidedoc with missing images. Either we need to repost this game with a blank `README.md` or just remove it from the "Community Games" gallery. The repo for this game (https://github.com/napsterix/furry) no longer exists so the image paths in the `README.md` are now invalid.

I'm removing the game in this PR, what's the verdict?

Closes #3654

## README.md

```markdown
# furry ![Build Status Abzeichen](https://github.com/napsterix/furry/workflows/MakeCode/badge.svg)



## Diese Erweiterung verwenden

Dieses Repository kann als **Erweiterung** in MakeCode hinzugefügt werden.

* open https://arcade.makecode.com/
* klicke auf **Neues Projekt**
* klicke auf **Erweiterungen** unter dem Zahnrad-Menü
* search for the URL of this repository and import

## Diese Erweiterung bearbeiten

Um dieses Repository in MakeCode zu bearbeiten.

* open https://arcade.makecode.com/
* klicke auf **Importieren** und dann auf **Importiere URL**
* paste the repository URL and click import

## Blockvorschau

Dieses Bild zeigt den Blockcode vom letzten Commit im Master an.
Die Aktualisierung dieses Bildes kann einige Minuten dauern.

![Eine gerenderte Ansicht der Blöcke](https://github.com/napsterix/furry/raw/master/.makecode/blocks.png)

## Supported targets

* for PXT/arcade
* for PXT/arcade
(The metadata above is needed for package search.)
```