### PR TITLE
bump pxt common packages to 9.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "typescript": "^4.2.3"
     },
     "dependencies": {
-        "pxt-common-packages": "9.1.5",
+        "pxt-common-packages": "9.2.7",
         "pxt-core": "7.2.17"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Bump to pick up new pxt ref in pxt-common-packages to update the transitive dependencies