### PR TITLE
Add header bar logos and styles to HoC page

### DIFF
--- a/docs/hour-of-code-2021.html
+++ b/docs/hour-of-code-2021.html
@@ -144,13 +144,21 @@
     <body id="root" class="root background-eggplant" onload="handleOnLoad()">
         <div id="main" role="presentation">
             <nav id="header-bar" class="background-eggplant" style="height: 60px">
-                <div class="header-org-logo" role="menuitem">
-                    <img src="/static/logo/Microsoft_logo_rgb_W-white_D.png" alt="Microsoft">
+                <div class="header-bar-left">
+                    <div class="header-org-logo" role="menuitem">
+                        <img src="/static/logo/Microsoft_logo_rgb_W-white_D.png" alt="Microsoft">
+                    </div>
+                    <div class="header-org-logo-sm" role="menuitem">
+                        <img src="/static/logo/Microsoft_logo_rgb_W-white_D-square.png" alt="Microsoft">
+                    </div>
+                    <div class="header-title" role="menuitem"><span>@orgtitle@</span></div>
                 </div>
-                <div class="header-org-logo-sm" role="menuitem">
-                    <img src="/static/logo/Microsoft_logo_rgb_W-white_D-square.png" alt="Microsoft">
+                <div class="header-bar-right">
+                    <a class="header-icon" role="menuitem" aria-label="Return home" tabindex="0"
+                        href="https://arcade.makecode.com/">
+                        <i class="icon home" aria-hidden="true" role="presentation"></i>
+                    </a>
                 </div>
-                <div class="header-title" role="menuitem"><span>@orgtitle@</span></div>
             </nav>
 
             <header class="hoc-header background-marina">

--- a/docs/hour-of-code-2021.html
+++ b/docs/hour-of-code-2021.html
@@ -88,8 +88,8 @@
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-        <!-- TODO: Add Rowdies back in once the font is legally approved 
-            
+        <!-- TODO: Add Rowdies back in once the font is legally approved
+
         <link
             href="https://fonts.googleapis.com/css2?family=Rowdies&display=swap"
             rel="stylesheet"
@@ -143,8 +143,14 @@
 
     <body id="root" class="root background-eggplant" onload="handleOnLoad()">
         <div id="main" role="presentation">
-            <nav class="background-eggplant" style="height: 60px">
-                <!-- TODO: Bring in standardized Arcade navbar and remove style prop -->
+            <nav id="header-bar" class="background-eggplant" style="height: 60px">
+                <div class="header-org-logo" role="menuitem">
+                    <img src="/static/logo/Microsoft_logo_rgb_W-white_D.png" alt="Microsoft">
+                </div>
+                <div class="header-org-logo-sm" role="menuitem">
+                    <img src="/static/logo/Microsoft_logo_rgb_W-white_D-square.png" alt="Microsoft">
+                </div>
+                <div class="header-title" role="menuitem"><span>@orgtitle@</span></div>
             </nav>
 
             <header class="hoc-header background-marina">

--- a/docs/static/hour-of-code/2021/styles.css
+++ b/docs/static/hour-of-code/2021/styles.css
@@ -164,9 +164,18 @@ h5 {
 
 /* Navbar --------------------------------------------------------------------------- */
 
-#header-bar {
+#header-bar,
+#header-bar > div {
     display: flex;
     align-items: center;
+    flex: 1;
+}
+
+.header-bar-left {
+    justify-content: flex-start;
+}
+.header-bar-right {
+    justify-content: flex-end;
 }
 
 .header-org-logo {
@@ -197,6 +206,23 @@ h5 {
     color: white;
     margin-left: 1rem;
     margin-bottom: 1px;
+}
+
+a.header-icon {
+    height: 100%;
+    padding: 1rem;
+    color: white;
+    text-decoration: none;
+}
+
+a.header-icon:hover,
+a.header-icon:focus {
+    color: white;
+    opacity: 0.8;
+}
+
+a.header-icon i.icon {
+    height: unset;
 }
 
 /* Header --------------------------------------------------------------------------- */

--- a/docs/static/hour-of-code/2021/styles.css
+++ b/docs/static/hour-of-code/2021/styles.css
@@ -1,8 +1,8 @@
 /*
 
-Hour of Code 2021 Theming 
+Hour of Code 2021 Theming
 
--- Colors: 
+-- Colors:
 ---- #FFFFFF
 ---- #000000
 ---- #3DC1AA (Marina)
@@ -10,9 +10,9 @@ Hour of Code 2021 Theming
 ---- #DE594B (Papaya)
 ---- #453052 (Eggplant)
 
--- Fonts: 
+-- Fonts:
 ---- Rowdies (Display)
----- Roboto (Body) 
+---- Roboto (Body)
 */
 
 /* Global --------------------------------------------------------------------------- */
@@ -160,6 +160,43 @@ h5 {
 }
 .eggplant {
     color: #453052;
+}
+
+/* Navbar --------------------------------------------------------------------------- */
+
+#header-bar {
+    display: flex;
+    align-items: center;
+}
+
+.header-org-logo {
+    display: flex;
+}
+.header-org-logo-sm {
+    display: none;
+}
+
+.header-org-logo img,
+.header-org-logo-sm img {
+    margin: 0 1rem;
+    height: 1.4rem;
+    flex-shrink: 0;
+}
+
+.header-title:before {
+    content: "";
+    position: relative;
+    height: 1.5rem;
+    border-left: 2px solid white;
+}
+
+.header-title span {
+    font-family: 'Segoe UI',Tahoma,Geneva,Verdana;
+    font-size: 18px;
+    font-weight: 700;
+    color: white;
+    margin-left: 1rem;
+    margin-bottom: 1px;
 }
 
 /* Header --------------------------------------------------------------------------- */


### PR DESCRIPTION
i'm not going to do it for this year but i'll file an issue for (after HoC) moving this header bar into a separate HTML file so that we can use it for docs pages that don't use the shared docs template

![image](https://user-images.githubusercontent.com/34112083/136107177-93c3cb8e-2d45-4ef7-b1b9-4f770f5f3b7a.png)

@soniakandah happy to make any changes!