### PR TITLE
Add telemetry for hour of code landing page

### DIFF
--- a/docs/hour-of-code-2021.html
+++ b/docs/hour-of-code-2021.html
@@ -114,32 +114,6 @@
         <script>
             // TODO: update tracking for 2021
             function handleOnLoad() {
-                document
-                    .querySelector('#openhome')
-                    .addEventListener('click', function () {
-                        window.pxtTickEvent('hourofcode2020.home', {
-                            src: 'main'
-                        });
-                    });
-
-                document
-                    .querySelector('#playbutton')
-                    .addEventListener('click', function () {
-                        window.pxtTickEvent('hourofcode2020.play');
-                    });
-
-                document
-                    .querySelector('#designbutton')
-                    .addEventListener('click', function () {
-                        window.pxtTickEvent('hourofcode2020.design');
-                    });
-
-                document
-                    .querySelector('#codebutton')
-                    .addEventListener('click', function () {
-                        window.pxtTickEvent('hourofcode2020.code');
-                    });
-
                 var langPicker = document.querySelector('#langpicker');
                 if (langPicker) {
                     langPicker.remove();

--- a/docs/hour-of-code/educators-2021.html
+++ b/docs/hour-of-code/educators-2021.html
@@ -114,14 +114,6 @@
 
         <script>
             function handleOnLoad() {
-                document
-                    .querySelector('#openhome')
-                    .addEventListener('click', function () {
-                        window.pxtTickEvent('hourofcode2020.home', {
-                            src: 'educators'
-                        });
-                    });
-
                 var langPicker = document.querySelector('#langpicker');
                 if (langPicker) {
                     langPicker.remove();
@@ -139,6 +131,7 @@
             >
                 <div class="header-bar-left">
                     <a href="https://www.microsoft.com/en-us/makecode"
+                        onClick="window.pxtTickEvent('hourofcode2021.header.logo')"
                         ><div class="header-org-logo" role="menuitem">
                             <img
                                 src="/static/logo/Microsoft_logo_rgb_W-white_D.png"
@@ -163,6 +156,7 @@
                         aria-label="Return home"
                         tabindex="0"
                         href="https://arcade.makecode.com/"
+                        onClick="window.pxtTickEvent('hourofcode2021.header.home')"
                     >
                         <i
                             class="icon home"
@@ -208,6 +202,7 @@
                         href="http://aka.ms/makecode"
                         rel="noreferrer"
                         target="_blank"
+                        onClick="window.pxtTickEvent('hourofcode2021.educator.learnmore')"
                         >http://aka.ms/makecode</a
                     >.
                 </p>
@@ -232,6 +227,7 @@
                             href="https://arcade.makecode.com/hardware"
                             rel="noreferrer"
                             target="_blank"
+                            onClick="window.pxtTickEvent('hourofcode2021.educator.hardware')"
                             >https://arcade.makecode.com/hardware</a
                         >.
                     </p>
@@ -420,6 +416,7 @@
                             href="https://www.instagram.com/msmakecode"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.social.instagram')"
                         >
                             <i class="icon instagram"></i>
                         </a>
@@ -427,6 +424,7 @@
                             href="https://www.youtube.com/microsoftmakecode"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.social.youtube')"
                         >
                             <i class="icon youtube"></i>
                         </a>
@@ -434,6 +432,7 @@
                             href="https://twitter.com/msmakecode"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.social.twitter')"
                         >
                             <i class="icon twitter"></i>
                         </a>
@@ -441,6 +440,7 @@
                             href="https://www.twitch.tv/msmakecode"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.social.twitch')"
                         >
                             <i class="icon twitch"></i>
                         </a>
@@ -448,6 +448,7 @@
                             href="https://www.tiktok.com/@msmakecode"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.social.tiktok')"
                         >
                             <svg
                                 aria-hidden="true"
@@ -480,18 +481,21 @@
                         href="https://www.microsoft.com/en-us/makecode/about"
                         target="_blank"
                         rel="noreferrer"
+                        onClick="window.pxtTickEvent('hourofcode2021.footer.about')"
                         >Microsoft MakeCode</a
                     >
                     <a
                         href="https://www.microsoft.com/en-us/legal/terms-of-use"
                         target="_blank"
                         rel="noreferrer"
+                        onClick="window.pxtTickEvent('hourofcode2021.footer.terms')"
                         >Terms of Use</a
                     >
                     <a
                         href="https://privacy.microsoft.com/en-us/privacystatement"
                         target="_blank"
                         rel="noreferrer"
+                        onClick="window.pxtTickEvent('hourofcode2021.footer.privacy')"
                         >Privacy</a
                     >
                 </div>


### PR DESCRIPTION
@Jaqster @abchatra hour of code 2021 ticks! let me know if you want any of these renamed or changed

header:
- `hourofcode2021.header.logo` - Microsoft | Makecode logo click
- `hourofcode2021.header.home` - home icon click

HoC skillmap activity:
- `hourofcode2021.skillmap.open.code` - skillmap open via "Code a Game"
- `hourofcode2021.skillmap.open.launch` - skillmap open via "Launch Activity"
- `hourofcode2021.skillmap.educator` - skillmap educator info click

gamejam:
- `hourofcode2021.gamejam` - gamejam "Learn More" click

carousel (these both have a property called `item` which can be: `hourofcode2020`, `skillmap.beginner`, `skillmap.rockstar`, `skillmap.jungle`, `minecraft`, or `microbit`)
- `hourofcode2021.carousel.list` - click on a carousel list item
- `hourofcode2021.carousel.action` - click on a carousel call to action 

social:
- `hourofcode2021.social.instagram`
- `hourofcode2021.social.youtube`
- `hourofcode2021.social.twitter`
- `hourofcode2021.social.twitch`
- `hourofcode2021.social.tiktok`

footer
- `hourofcode2021.footer.about`
- `hourofcode2021.footer.terms`
- `hourofcode2021.footer.privacy`

for https://github.com/microsoft/pxt-arcade/issues/4179