### PR TITLE
Update hour of code game jam link and image

### DIFF
--- a/docs/gamejam-ref.json
+++ b/docs/gamejam-ref.json
@@ -1,3 +1,3 @@
 {
-    "redirect": "/gamejam/ocean"
+    "redirect": "/gamejam/global-2021"
 }

--- a/docs/hour-of-code-2021.html
+++ b/docs/hour-of-code-2021.html
@@ -270,7 +270,9 @@
                         ><h5 class="display-font">Learn More</h5></a
                     >
                 </div>
-                <div class="hero background-sunflower"></div>
+                <div class="hero background-sunflower"
+                    style="background-image: url('./static/gamejam/jams/global-2021/assets/banner.png');"
+                ></div>
             </section>
 
             <section class="hoc-section-02">


### PR DESCRIPTION
this adds the game jam banner image to the hour of code page, and updates the ref so that arcade.makecode.com/gamejam redirects to the /gamejam/global-2021 page instead of the ocean jam. we should merge this when the banner is finalized and the gamejam page is ready for people to see

![image](https://user-images.githubusercontent.com/34112083/137564036-a1a029fc-8549-4af1-86a8-2fc425a41e7c.png)
