### PR TITLE
fix header bar spacing in safari

### DIFF
--- a/docs/static/hour-of-code/2021/styles.css
+++ b/docs/static/hour-of-code/2021/styles.css
@@ -201,6 +201,10 @@ h5 {
     flex-shrink: 0;
 }
 
+.header-title {
+    white-space: nowrap;
+}
+
 .header-title:before {
     content: '';
     position: relative;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/4221

I was gonna go with 

```css
.header-title:before {
    display: inline-block
}
```

but that makes the height property unused / the line becomes slightly smaller. It looks like this fix is the slightly more accurate one to account for differences between browsers anyways.