### PR TITLE
Add parent page linking to all previous hour of code activities

### DIFF
--- a/docs/hour-of-code/all.md
+++ b/docs/hour-of-code/all.md
@@ -1,0 +1,27 @@
+# Hour of Code
+
+Join us in celebrating this year's Computer Science Education Week by playing, designing and coding your very own retro arcade games!
+
+## Activities
+
+```codecard
+[
+    {
+        "name": "2021 Hour of Code",
+        "description": "Code a fire-fighting airtanker plane with Microsoft MakeCode Arcade that sprays water to put out the forest fires!",
+        "url": "/hour-of-code-2021",
+        "imageUrl": "/static/hour-of-code/2021/forest-skillmap-game.gif"
+    },
+    {
+        "name": "2020 Hour of Code",
+        "description": "Design game art, code a shark adventure, and play a logic game in these three hour-long activities!",
+        "url": "/hour-of-code-2020",
+        "imageUrl": "/static/hour-of-code/2020/card.png"
+    }
+]
+```
+
+## See also
+
+[2021 Hour of Code](/hour-of-code-2021),
+[2020 Hour of Code](/hour-of-code-2020)


### PR DESCRIPTION
for https://github.com/microsoft/pxt-arcade/issues/4166

after this is merged in i will update the aka.ms link to /hour-of-code/all! we can redesign/make it look nicer in the future, just putting this up now so users don't get confused

![image](https://user-images.githubusercontent.com/34112083/139117129-6ad80827-697c-4733-8c1c-58b5880aa88c.png)
