### PR TITLE
Final pass over tick events for hour of code, educator, and game jam pages

### DIFF
--- a/docs/gamejam/global-2021.html
+++ b/docs/gamejam/global-2021.html
@@ -139,17 +139,17 @@
                         Global MakeCode Arcade Game Jam!
                     </h3>
                     <p>
-                        Microsoft MakeCode and the US State Department have partnered to 
+                        Microsoft MakeCode and the US State Department have partnered to
                         bring you the Global MakeCode Arcade Game Jam!
-                        Practice your game development skills in this worldwide 
+                        Practice your game development skills in this worldwide
                         challenge using MakeCode Arcade.
                     </p>
                     <p>
                         Once the theme of the Game Jam is announced on
                         <b class="sunflower">November 29th</b>, you'll have
-                        three weeks to create and submit your game with 
-                        the chance to be featured on the Game Jam page, 
-                        MakeCode live stream and social media channels! 
+                        three weeks to create and submit your game with
+                        the chance to be featured on the Game Jam page,
+                        MakeCode live stream and social media channels!
                     </p>
                 </div>
             </section>
@@ -189,7 +189,7 @@
                         <p>
                             Create a game that helps others
                             understand the impact of behaviors on our planet and
-                            how we must take bold action immediately. 
+                            how we must take bold action immediately.
                             whether your game focuses
                             on the way humans impact the melting of the ice
                             caps or ideas for renewable energy, share
@@ -224,16 +224,16 @@
                     </li>
                     <li>
                         All games must be submitted by someone who is at least
-                        13 years old. Students under 13 can participate, but 
+                        13 years old. Students under 13 can participate, but
                         someone 13 or over must submit their game.
                     </li>
                     <li>
-                        All games must be submitted by 12 am midnight PST on 
+                        All games must be submitted by 12 am midnight PST on
                         <b class="sunflower">December 17th</b>.
-                    </li>  
+                    </li>
                     <li>
                         You are welcome to work together with others on a game.
-                    </li>   
+                    </li>
                 </ol>
             </section>
 
@@ -252,6 +252,7 @@
                             href="https://www.instagram.com/msmakecode"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.social.instagram')"
                             >Instagram</a
                         >
                         or
@@ -259,6 +260,7 @@
                             href="https://twitter.com/msmakecode"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.social.twitter')"
                             >Twitter</a
                         >
                         to find out who made our list of favorites.
@@ -276,6 +278,7 @@
                             href="https://forms.office.com/r/Q8emYkxNPL"
                             target="_blank"
                             rel="noopener noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.gamejam.submit')"
                         >
                             <h5 class="display-font">Submit Your Game</h5>
                         </a>
@@ -299,6 +302,7 @@
                                 href="https://arcade.makecode.com/--skillmap#beginner"
                                 target="_blank"
                                 rel="noreferrer"
+                                onClick="window.pxtTickEvent('hourofcode2021.gamejam.skillmap')"
                                 ><h5 class="display-font">
                                     Beginner Skillmap
                                 </h5></a
@@ -308,6 +312,7 @@
                                 href="https://arcade.makecode.com/hour-of-code"
                                 target="_blank"
                                 rel="noreferrer"
+                                onClick="window.pxtTickEvent('hourofcode2021.gamejam.hoc')"
                                 ><h5 class="display-font">Hour of Code</h5></a
                             >
                         </div>
@@ -333,6 +338,7 @@
                         Platform, learning objectives, and more!
                     </p>
                     <a class="btn" href="" target="_blank" rel="noreferrer"
+                        onClick="window.pxtTickEvent('hourofcode2021.gamejam.training')"
                         ><h5 class="display-font">Free Training</h5></a
                     >
                 </section>
@@ -345,32 +351,33 @@
                     </p>
                     <a class="btn" href="https://arcade.makecode.com/gamejam/lessons/box"
                         target="_blank" rel="noreferrer"
+                        onClick="window.pxtTickEvent('hourofcode2021.gamejam.box')"
                         ><h5 class="display-font">Game Jam Guide</h5></a
                     >
                 </section>
             </section>
 
-            <!-- TODO: Winners section 
-                Sections: 
-                    - Game Jam Winners! 
-                        - Title 
+            <!-- TODO: Winners section
+                Sections:
+                    - Game Jam Winners!
+                        - Title
                         - Paragraph
                     - First Place
-                        - Image 
+                        - Image
                         - Paragraph
-                    - Second Place 
-                        - Image 
+                    - Second Place
+                        - Image
                         - Paragraph
-                    - Third Place 
-                        - Image 
+                    - Third Place
+                        - Image
                         - Paragraph
                     - Honorable Mentions
-                        - Paragraph 
-                        - Grid 
-                            - Image 
-                            - Author / Link 
+                        - Paragraph
+                        - Grid
+                            - Image
+                            - Author / Link
                             - Description
-                    - Gallery 
+                    - Gallery
                         <div class="segment gallery">
                             <h2>Gallery</h2>
                             <p class="description">Check out the submitted games!</p>

--- a/docs/hour-of-code-2021.html
+++ b/docs/hour-of-code-2021.html
@@ -227,6 +227,7 @@
                 };
 
                 function modalOpen() {
+                    window.pxtTickEvent("hourofcode2021.video.open");
                     let modal = document.getElementById('video-modal');
                     let video = document.getElementById('video');
                     modal.classList.remove('closed');
@@ -236,6 +237,7 @@
                 }
 
                 function modalClose() {
+                    window.pxtTickEvent("hourofcode2021.video.close");
                     let modal = document.getElementById('video-modal');
                     let video = document.getElementById('video');
                     modal.classList.remove('open');

--- a/docs/hour-of-code/educators-2021.html
+++ b/docs/hour-of-code/educators-2021.html
@@ -218,7 +218,7 @@
                             href="http://aka.ms/makecode"
                             rel="noreferrer"
                             target="_blank"
-                            onClick="window.pxtTickEvent('hourofcode2021.educator.learnmore')"
+                            onClick="window.pxtTickEvent('hourofcode2021.educator.learnmore.link')"
                             >http://aka.ms/makecode</a
                         >.
                     </p>
@@ -227,7 +227,7 @@
                         target="_blank"
                         rel="noreferrer"
                         href="http://aka.ms/makecode"
-                        onClick="window.pxtTickEvent('hourofcode2021.educator.learnmore')"
+                        onClick="window.pxtTickEvent('hourofcode2021.educator.learnmore.button')"
                     >
                         <!--TODO: Make sure link above is correct-->
                         <h5 class="display-font">Learn More</h5></a
@@ -509,6 +509,7 @@
                             href="https://forum.makecode.com"
                             target="_blank"
                             rel="noreferrer"
+                            onClick="window.pxtTickEvent('hourofcode2021.educator.forum')"
                             ><h5 class="display-font">Join the Forum</h5>
                         </a>
                     </div>


### PR DESCRIPTION
new tick events across the three pages:

### Hour of Code
- `hourofcode2021.video.open`
- `hourofcode2021.video.close`

### Educator Page
- `hourofcode2021.educator.learnmore.link`
- `hourofcode2021.educator.learnmore.button`
- `hourofcode2021.educator.forum`

### Game Jam
- `hourofcode2021.gamejam.submit`
- `hourofcode2021.gamejam.skillmap`
- `hourofcode2021.gamejam.hoc`
- `hourofcode2021.gamejam.training`
- `hourofcode2021.gamejam.box`

@soniakandah @ElizabethRiffle please let me know if you add any more links or buttons (anything the user can click), otherwise i think we're set on telemetry!

for https://github.com/microsoft/pxt-arcade/issues/4179, will close the issue after this change goes in and i classify the new tick events