### PR TITLE
Add new badge/certificate authoring

### DIFF
--- a/docs/skillmap/beginner-skillmap.md
+++ b/docs/skillmap/beginner-skillmap.md
@@ -3,7 +3,7 @@
 * description: Learn to create arcade games of your own by completing tutorials that focus on greeting cards, a clicker game, and a collector game starring a dinosuar that's determined to save dino babies!
 * infoUrl: skillmap/educator-info/basic-map-info
 * bannerUrl: /static/skillmap/backgrounds/beg-map-tile.png
-* backgroundurl: /static/skillmap/backgrounds/beg-comp.png  
+* backgroundurl: /static/skillmap/backgrounds/beg-comp.png
 * primarycolor: #ff7f41
 * secondarycolor: #fff53d
 * tertiarycolor: #87f2ff
@@ -27,7 +27,7 @@
 * tags: optional, easy, introduction
 * next: pusherA, pusherB
 
-* url: /skillmap/interface/activity1 
+* url: /skillmap/interface/activity1
 * imageUrl: /static/skillmap/interface/interface-activity-1.gif
 
 ### pusherA
@@ -54,7 +54,7 @@
 * tags: easy, story, creative, card
 * next: story-activity2
 
-* url: /skillmap/story/story1 
+* url: /skillmap/story/story1
 * imageUrl: /static/skillmap/story/story-comp.png
 
 
@@ -66,7 +66,7 @@
 * next: story-activity3
 * reqired: 1 story
 
-* url: /skillmap/story/story2 
+* url: /skillmap/story/story2
 * imageUrl: /static/skillmap/story/story-activity-2.gif
 
 
@@ -78,7 +78,7 @@
 * tags: easy, story, joke, share
 * next: pusher2, beginner-cert-1
 
-* url: /skillmap/story/story3 
+* url: /skillmap/story/story3
 * imageUrl: /static/skillmap/story/muffins.gif
 
 
@@ -113,7 +113,7 @@
 * tags: easy, clicker, game
 * next: clicker-activity2
 
-* url: /skillmap/clicker-themed/clickert1 
+* url: /skillmap/clicker-themed/clickert1
 * imageUrl: /static/skillmap/clicker/clicker-comp.png
 
 
@@ -121,11 +121,11 @@
 ### clicker-activity2
 * name: Button Clicker
 * type: tutorial
-* description: Add a visual button to your clicker! 
+* description: Add a visual button to your clicker!
 * tags: easy, clicker, game, images
 * next: pusher3, clicker-activity3
 
-* url: /skillmap/clicker-themed/clickert2 
+* url: /skillmap/clicker-themed/clickert2
 * imageUrl: /static/skillmap/clicker/clickert2.gif
 
 
@@ -136,7 +136,7 @@
 * tags: easy, clicker, projectiles
 * next: pusher3, beginner-cert-2
 
-* url: /skillmap/clicker-themed/clickert3 
+* url: /skillmap/clicker-themed/clickert3
 * imageUrl: /static/skillmap/clicker/clickert3.gif
 
 
@@ -158,7 +158,7 @@
 * imageUrl: /static/skillmap/certificates/clicker-cert.png
 
 
-## Rescue the Baby Dinos 
+## Rescue the Baby Dinos
 * required: 1 clicker
 
 ### collector-activity1
@@ -168,9 +168,9 @@
 * type: tutorial
 * description: Create a swarm of baby dinosaurs to run down the city streets.
 * tags: easy, collector, game
-* next: pusher5, collector-activity2 
+* next: pusher5, collector-activity2
 
-* url: /skillmap/collector-themed/collectort1 
+* url: /skillmap/collector-themed/collectort1
 * imageUrl: /static/skillmap/collector/collector-comp.png
 
 
@@ -183,7 +183,7 @@
 * tags: easy, collector, game, projectiles
 * next: collector-activity3
 
-* url: /skillmap/collector-themed/collectort2 
+* url: /skillmap/collector-themed/collectort2
 * imageUrl: /static/skillmap/collector/collectort2.gif
 
 
@@ -218,8 +218,12 @@
 * url: /static/skillmap/certificates/collector-game.pdf
 * imageUrl: /static/skillmap/certificates/collector-cert.png
 * rewards:
-    * certificate: /static/skillmap/certificates/collector-game.pdf
-    * completion-badge: /static/badges/badge-beginner.png
+    * certificate:
+        * url: /static/skillmap/certificates/collector-game.pdf
+        * preview: /static/skillmap/certificates/collector-cert.png
+    * completion-badge:
+        * image: /static/badges/badge-beginner.png
+        * name: Beginner
 
 
 ### pusher5

--- a/docs/skillmap/forest.md
+++ b/docs/skillmap/forest.md
@@ -77,8 +77,12 @@
 * next: forest6
 * position: 3 2
 * rewards:
-    * certificate: /static/skillmap/certificates/forest-cert.pdf
-    * completion-badge: /static/badges/badge-forest.png
+    * certificate:
+        * url: /static/skillmap/certificates/forest-cert.pdf
+        * preview: /static/skillmap/certificates/forest-cert.png
+    * completion-badge:
+        * image: /static/badges/badge-forest.png
+        * name: Save the Forest
 * actions:
     * map: [Try the Jungle Monkey Skillmap](/skillmap/jungle)
     * map: [Try the Space Explorer Skillmap](/skillmap/space)

--- a/docs/skillmap/jungle.md
+++ b/docs/skillmap/jungle.md
@@ -112,8 +112,12 @@
     * map: [Try our Space Explorer](/skillmap/space)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/jungle-cert.pdf
-    * completion-badge: /static/badges/badge-jungle.png
+    * certificate:
+        * url: /static/skillmap/certificates/jungle-cert.pdf
+        * preview: /static/skillmap/certificates/jungle-cert.png
+    * completion-badge:
+        * image: /static/badges/badge-jungle.png
+        * name: Jungle Monkey
 
 
 

--- a/docs/skillmap/racer.md
+++ b/docs/skillmap/racer.md
@@ -54,6 +54,9 @@
     * map: [Try Space Explorer](/skillmap/space)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/racer-game.pdf
-    * completion-badge: /static/badges/badge-racer.png
+    * certificate:
+        * url: /static/skillmap/certificates/racer-game.pdf
+    * completion-badge:
+        * image: /static/badges/badge-racer.png
+        * name: Monster Racer
 

--- a/docs/skillmap/rockstar.md
+++ b/docs/skillmap/rockstar.md
@@ -57,6 +57,10 @@
     * map: [Try our Space Explorer](/skillmap/space)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/rockstar-cert.pdf
-    * completion-badge: /static/badges/badge-rockstar.png
+    * certificate:
+        * url: /static/skillmap/certificates/rockstar-cert.pdf
+        * preview: /static/skillmap/certificates/rockstar-cert.png
+    * completion-badge:
+        * image: /static/badges/badge-rockstar.png
+        * name: 80's Rockstar
 

--- a/docs/skillmap/shark.md
+++ b/docs/skillmap/shark.md
@@ -83,6 +83,10 @@
     * map: [Try Jungle Monkey Jump](/skillmap/jungle)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/shark-cert.pdf
-    * completion-badge: /static/badges/badge-shark.png
+    * certificate:
+        * url: /static/skillmap/certificates/shark-cert.pdf
+        * preview: /static/skillmap/certificates/shark-cert.png
+    * completion-badge:
+        * image: /static/badges/badge-shark.png
+        * name: Shark Splash
 

--- a/docs/skillmap/space.md
+++ b/docs/skillmap/space.md
@@ -1,6 +1,6 @@
 # Create a Space Adventure
 * name: Create a Space Adventure Game
-* description: Make a Galaga-style game by following this short series of tutorials. You will create a rocket that fires projectiles at enemies, design your outerspace view, create amazing animations, and MORE!  What are you waiting for?  Double-click the first level to begin! 
+* description: Make a Galaga-style game by following this short series of tutorials. You will create a rocket that fires projectiles at enemies, design your outerspace view, create amazing animations, and MORE!  What are you waiting for?  Double-click the first level to begin!
 * infoUrl: skillmap/educator-info/space-map-info
 * bannerUrl: /static/skillmap/space/spacet6.gif
 * backgroundurl: /static/skillmap/backgrounds/space-comp.png
@@ -50,7 +50,7 @@
 ### space-activity4a
 * name: All Shook Up
 * type: tutorial
-* description: Animate your ship 
+* description: Animate your ship
 * tags: intermediate, animations
 * next: space-activity4
 * url: /skillmap/space/space4a
@@ -101,7 +101,11 @@
     * map: [Try Jungle Monkey Jump](/skillmap/jungle)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/space-cert.pdf
-    * completion-badge: /static/badges/badge-space.png
+    * certificate:
+        * url: /static/skillmap/certificates/space-cert.pdf
+        * preview: /static/skillmap/certificates/space-cert.png
+    * completion-badge:
+        * image: /static/badges/badge-space.png
+        * name: Space Explorer
 
 

--- a/docs/skillmap/star.md
+++ b/docs/skillmap/star.md
@@ -3,7 +3,7 @@
 * description: Learn to create a clicker game and quickly rack up the points as you applaud your favorite stars from Sing 2.
 * infoUrl: skillmap/educator-info/star-map-info
 * bannerUrl: /static/skillmap/backgrounds/star.png
-* backgroundurl: /static/skillmap/backgrounds/star-comp.png  
+* backgroundurl: /static/skillmap/backgrounds/star-comp.png
 * primarycolor: #ff7f41
 * secondarycolor: #fff53d
 * tertiarycolor: #87f2ff
@@ -26,7 +26,7 @@
 * tags: easy, clicker, points
 * next: star-activity2
 
-* url: /skillmap/clicker-star/star1 
+* url: /skillmap/clicker-star/star1
 * imageUrl: /static/skillmap/clicker-star/star-comp.png
 
 
@@ -34,11 +34,11 @@
 ### star-activity2
 * name: Join the Audience
 * type: tutorial
-* description: Add an audience that applauds as you click! 
+* description: Add an audience that applauds as you click!
 * tags: easy, clicker, game, events
 * next: star-activity3
 
-* url: /skillmap/clicker-star/clickert2 
+* url: /skillmap/clicker-star/clickert2
 * imageUrl: /static/skillmap/clicker-star/clickert2.gif
 
 
@@ -49,7 +49,7 @@
 * tags: easy, clicker, projectiles
 * next: star-activity4
 
-* url: /skillmap/clicker-star/clickert3 
+* url: /skillmap/clicker-star/clickert3
 * imageUrl: /static/clicker-star/clicker-star/clickert3.gif
 
 
@@ -60,7 +60,7 @@
 * tags: easy, clicker, projectiles, arrays
 * next: star-activity5
 
-* url: /skillmap/clicker-star/clickert4 
+* url: /skillmap/clicker-star/clickert4
 * imageUrl: /static/skillmap/clicker-star/clickert4.gif
 
 
@@ -71,7 +71,7 @@
 * tags: easy, clicker, projectiles
 * next: star-cert-2
 
-* url: /skillmap/clicker-star/clickert5 
+* url: /skillmap/clicker-star/clickert5
 * imageUrl: /static/skillmap/clicker-star/clickert5.gif
 
 
@@ -86,7 +86,11 @@
     * map: [Try Space Explorer](/skillmap/space)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/star-game.pdf
-    * completion-badge: /static/badges/badge-star.png
+    * certificate:
+        * url: /static/skillmap/certificates/star-game.pdf
+        * preview: /static/skillmap/certificates/star-cert.png
+    * completion-badge:
+        * image: /static/badges/badge-star.png
+        * name: Sing 2
 
 

--- a/docs/skillmap/turkey.md
+++ b/docs/skillmap/turkey.md
@@ -56,6 +56,9 @@
     * map: [Try Space Explorer](/skillmap/space)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/turkey-cert.pdf
-    * completion-badge: /static/badges/badge-turkey.png
-
+    * certificate:
+        * url: /static/skillmap/certificates/turkey-cert.pdf
+        * preview: /static/skillmap/certificates/turkey-cert.png
+    * completion-badge:
+        * image:/static/badges/badge-turkey.png
+        * name: Turkey Day!

--- a/docs/skillmap/zoo.md
+++ b/docs/skillmap/zoo.md
@@ -3,7 +3,7 @@
 * description: Ever wonder what it takes to be a zookeeper? The answer may surprise you...
 * infoUrl: skillmap/educator-info/zookeeper-map-info
 * bannerurl: /static/skillmap/zoo/zoo-welcome.png
-* backgroundurl: /static/skillmap/backgrounds/zookeeper-bg.png 
+* backgroundurl: /static/skillmap/backgrounds/zookeeper-bg.png
 * primarycolor: #2EA9B0
 * secondarycolor: #fff609
 * tertiarycolor: #78DC52
@@ -94,5 +94,9 @@
     * map: [Try Beginner Skillmap](/skillmap/beginner)
     * editor: [Edit Your Project with a Full Toolbox](/)
 * rewards:
-    * certificate: /static/skillmap/certificates/zookeeper-license.pdf
-    * completion-badge: /static/badges/badge-zoo.png
+    * certificate:
+        * url: /static/skillmap/certificates/zookeeper-license.pdf
+        * preview: /static/skillmap/certificates/zookeeper-license.pdf
+    * completion-badge:
+        * image: /static/badges/badge-zoo.png
+        * name: Zookeeper


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4320

This PR is easier to view if you turn on the "ignore whitespace" option.

Adding the new authoring for the various skillmaps that specifies a shorter badge name and a certificate preview image. 

This should not be merged until we release the update.