### PR TITLE
Update broken thumbnails on time jam page

### DIFF
--- a/docs/static/gamejam/jams/time/info.json
+++ b/docs/static/gamejam/jams/time/info.json
@@ -84,7 +84,7 @@
             "author": "Agent 14"
         },
         {
-            "id": "02250-36892-43304-14557",
+            "id": "43601-79018-70540-71516",
             "title": "The Burger & The Duck",
             "author": "E-EnerG Gamecentral"
         },
@@ -179,7 +179,7 @@
             "author": "thesonicfan192"
         },
         {
-            "id": "01031-12206-01166-26436",
+            "id": "48329-11330-24936-94155",
             "title": "Rewind Redux 1 -The Puzzle of Time",
             "author": "Gokul S"
         },
@@ -264,7 +264,7 @@
             "author": "Samuel"
         },
         {
-            "id": "42992-43369-99949-54097",
+            "id": "09187-15057-60704-09504",
             "title": "escape the maze",
             "author": "gusiscute64"
         },


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4425

just re-shared the games with thumbnail/gif capture this time!