### PR TITLE
Ignore GIFs when generating npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "built/*.json",
         "built/*.d.ts",
         "sim/public",
-        "docs/**"
+        "docs/**",
+        "!docs/**/*.gif"
     ],
     "devDependencies": {
         "@types/marked": "^0.3.0",


### PR DESCRIPTION
attempting to fix the "Payload too large" error in the npm publish build step! this drops our package size from 200mb to like 70