### PR TITLE
Fixed typo with hero banner

### DIFF
--- a/docs/hero-banner.md
+++ b/docs/hero-banner.md
@@ -8,7 +8,7 @@ Here are some cool activities to get you started with your @boardname@!
 
 * name: Play the Monster Racer Tutorial
 * buttonLabel: Try Now
-* imageUrl: /static/banner/racer-banner.png
+* imageUrl: /static/banners/racer-banner.png
 * url: https://arcade.makecode.com/--skillmap#docs:/skillmap/racer
 * cardType: link
 ---


### PR DESCRIPTION
It should have been `banners` not `banner`.

I'll squash when tests pass.