### PR TITLE
Corrected package name 'sc' skillmap animations

### DIFF
--- a/docs/skillmap/sc/sc5.md
+++ b/docs/skillmap/sc/sc5.md
@@ -131,7 +131,7 @@ When you're done with this activity, click **Done** to return to the main page, 
 ```package
 pxt-tilemaps=github:microsoft/pxt-tilemaps/
 arcade-premium-life=github:jwunderl/arcade-premium-life/
-pxt-characterAnimations=github:microsoft/arcade-character-animations/
+arcade-character-animations=github:microsoft/arcade-character-animations/
 ```
 
 

--- a/docs/skillmap/sc/sc6.md
+++ b/docs/skillmap/sc/sc6.md
@@ -200,7 +200,7 @@ When you're done testing your project, click **Done** to return to the main page
 ```package
 pxt-tilemaps=github:microsoft/pxt-tilemaps/
 arcade-premium-life=github:jwunderl/arcade-premium-life/
-pxt-characterAnimations=github:microsoft/arcade-character-animations/
+arcade-character-animations=github:microsoft/arcade-character-animations/
 ```
 
 

--- a/docs/skillmap/sc/sc6a.md
+++ b/docs/skillmap/sc/sc6a.md
@@ -170,7 +170,7 @@ When you're done testing your project, click **Done** to return to the main page
 ```package
 pxt-tilemaps=github:microsoft/pxt-tilemaps/
 arcade-premium-life=github:jwunderl/arcade-premium-life/
-pxt-characterAnimations=github:microsoft/arcade-character-animations/
+arcade-character-animations=github:microsoft/arcade-character-animations/
 ```
 
 

--- a/docs/skillmap/sc/sc6b.md
+++ b/docs/skillmap/sc/sc6b.md
@@ -102,7 +102,7 @@ When you're done testing your project, click **Done** to return to the main page
 ```package
 pxt-tilemaps=github:microsoft/pxt-tilemaps/
 arcade-premium-life=github:jwunderl/arcade-premium-life/
-pxt-characterAnimations=github:microsoft/arcade-character-animations/
+arcade-character-animations=github:microsoft/arcade-character-animations/
 ```
 
 

--- a/docs/skillmap/sc/sc7.md
+++ b/docs/skillmap/sc/sc7.md
@@ -143,7 +143,7 @@ When you're done playing with your project, click **Done** to return to the main
 ```package
 pxt-tilemaps=github:microsoft/pxt-tilemaps/
 arcade-premium-life=github:jwunderl/arcade-premium-life/
-pxt-characterAnimations=github:microsoft/arcade-character-animations/
+arcade-character-animations=github:microsoft/arcade-character-animations/
 ```
 
 

--- a/docs/skillmap/sc/sc8.md
+++ b/docs/skillmap/sc/sc8.md
@@ -59,7 +59,7 @@ When you're done editing here, click **Done** to return to the main page and cho
 ```package
 pxt-tilemaps=github:microsoft/pxt-tilemaps/
 arcade-premium-life=github:jwunderl/arcade-premium-life/
-pxt-characterAnimations=github:microsoft/arcade-character-animations/
+arcade-character-animations=github:microsoft/arcade-character-animations/
 ```
 
 


### PR DESCRIPTION
The package name for the `arcade-character-animations` was incorrect.

`pxt-characterAnimations=github:microsoft/arcade-character-animations/`

-- corrected:

`arcade-character-animations=github:microsoft/arcade-character-animations/`

Fixes #3874, maybe.

I couldn't test this in the actual skillmap as my local serve crashed when trying to retrieve partner content for the splash.

Currently, help for the 'override' (`loopFrames2()`) of the character animation `loopFrames()` block isn't working.

![image](https://user-images.githubusercontent.com/27789908/153490676-fe9778d6-b9b2-403c-915c-7365f342cc50.png)

The help from the base extension itself IS working though:

![image](https://user-images.githubusercontent.com/27789908/153490066-bc63053a-664d-4a29-a39e-8575389b86e2.png)

We'll see if correcting the name fixes it. 🤞