### PR TITLE
update courses to remove cs intro series from home screen

### DIFF
--- a/docs/courses.md
+++ b/docs/courses.md
@@ -9,24 +9,6 @@ Structured courses for teaching computer science in the classroom.
 ```codecard
 [
     {
-        "name": "CS Intro 1",
-        "description": "A quarter length computer science course for beginning coders",
-        "url": "/courses/csintro1",
-        "imageUrl": "/static/courses/csintro1.png",
-        "largeImageUrl": "/static/courses/csintro1.gif"
-    }, {
-        "name": "CS Intro 2",
-        "description": "A quarter length continuation of the CS Intro 1 course",
-        "url": "/courses/csintro2",
-        "imageUrl": "/static/courses/csintro2.png",
-        "largeImageUrl": "/static/courses/csintro2.gif"
-    }, {
-        "name": "CS Intro 3",
-        "description": "A quarter length transition from blocks to JavaScript",
-        "url": "/courses/csintro3",
-        "imageUrl": "/static/courses/csintro3.png",
-        "largeImageUrl": "/static/courses/csintro3.gif"
-    }, {
         "name": "AP Computer Science Principles",
         "description": "AP endorsed introductory class for High School students. The course is designed to attract students of all backgrounds, experience levels, and interests.",
         "url": "https://makecode.com/csp",
@@ -61,10 +43,6 @@ The games they make in the course can run on the GameGo device! Courses are free
 
 ## See also
 
-[CS Intro Home Page](/courses/csintro),
-[CS Intro 1](/courses/csintro1),
-[CS Intro 2](/courses/csintro2),
-[CS Intro 3](/courses/csintro3)
-
+[AP Computer Science Principles](https://makecode.com/csp)
 [GameGo Beginner](https://make2learn.tinkergen.com/course/?sku=604182001),
 [GameGo Intermediate](https://make2learn.tinkergen.com/course/?sku=604182003)

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -76,13 +76,13 @@
     {
         "name": "Courses",
         "url": "/courses",
-        "imageUrl": "/static/courses/csintro1.png",
-        "largeImageUrl": "/static/courses/csintro1.gif"
+        "imageUrl": "/static/courses/csp.png",
+        "largeImageUrl": "/static/courses/csp.png"
     },
     {
         "name": "Hardware",
         "url": "/hardware",
-        "imageUrl": "/static/hardware/ghiarcade.jpg"
+        "imageUrl": "/static/hardware/meowbit.png"
     },
     {
         "name": "How to Make a Game Videos",


### PR DESCRIPTION
close https://github.com/microsoft/pxt-arcade/issues/4653

Note this page is used to generate both the homescreen carousel & is the /courses page so it completes both parts mentioned in the issue~