### PR TITLE
remove invalid links / info in csintro courses

### DIFF
--- a/docs/courses/csintro1/about/teachers.md
+++ b/docs/courses/csintro1/about/teachers.md
@@ -1,36 +1,3 @@
 # Teacher Resources
 
-In addition to the online course, materials are available to assist in teaching this course for a structured classroom setting.
-
-## Instructor Materials on MSIA
-
-The materials for teachers are currently in development and are released through [Microsoft Imagine Academy](https://imagineacademy.info/index.php) (MSIA) Membership.
-
-## Available Courses
-
-### Released Courses
-
-* MakeCode Arcade Part 1: Block Coding
-
-### Courses in Development
-
-* MakeCode Arcade Part 2: Block Coding - Continued
-* MakeCode Arcade Part 3: JavaScript
-* MakeCode Arcade Part 4: JavaScript and HTML/CSS
-
-## Materials Included
-
-* Microsoft OneNote notebooks for students and teachers
-* PowerPoint Slides for framing lessons
-* Rubrics for Lessons
-* Sample Solutions to student activities
-* Teaching Guide, including Tips Videos
-* Multiple Choice Review Quiz/Test
-
-## Download Course Materials from MSIA
-
-Follow these instructions to get the course materials:
-
-1. [Sign in to MSIA](https://imagineacademy.info/index.php/educators) using your membership identity
-2. Navigate to [Computer Science Learning Path](https://member.imagineacademy.microsoft.com/learning-path#csps)
-3. Expand **Building Games** to select the download materials
+For any questions please check out the [Educator's Lounge](https://forum.makecode.com/c/educators-lounge/24) on our forum.

--- a/docs/courses/csintro2/about/teachers.md
+++ b/docs/courses/csintro2/about/teachers.md
@@ -1,36 +1,3 @@
 # Teacher Resources
 
-In addition to the online course, materials are available to assist in teaching this course for a structured classroom setting.
-
-## Instructor Materials on MSIA
-
-The materials for teachers are currently in development and are released through [Microsoft Imagine Academy](https://imagineacademy.info/index.php) (MSIA) Membership.
-
-## Available Courses
-
-### Released Courses
-
-* MakeCode Arcade Part 1: Block Coding
-
-### Courses in Development
-
-* MakeCode Arcade Part 2: Block Coding - Continued
-* MakeCode Arcade Part 3: JavaScript
-* MakeCode Arcade Part 4: JavaScript and HTML/CSS
-
-## Materials Included
-
-* Microsoft OneNote notebooks for students and teachers
-* PowerPoint Slides for framing lessons
-* Rubrics for Lessons
-* Sample Solutions to student activities
-* Teaching Guide, including Tips Videos
-* Multiple Choice Review Quiz/Test
-
-## Download Course Materials from MSIA
-
-Follow these instructions to get the course materials:
-
-1. [Sign in to MSIA](https://imagineacademy.info/index.php/educators) using your membership identity
-2. Navigate to [Computer Science Learning Path](https://member.imagineacademy.microsoft.com/learning-path#csps)
-3. Expand **Building Games** to select the download materials
+For any questions please check out the [Educator's Lounge](https://forum.makecode.com/c/educators-lounge/24) on our forum.

--- a/docs/courses/csintro3/about/teachers.md
+++ b/docs/courses/csintro3/about/teachers.md
@@ -1,36 +1,3 @@
 # Teacher Resources
 
-In addition to the online course, materials are available to assist in teaching this course for a structured classroom setting.
-
-## Instructor Materials on MSIA
-
-The materials for teachers are currently in development and are released through [Microsoft Imagine Academy](https://imagineacademy.info/index.php) (MSIA) Membership.
-
-## Available Courses
-
-### Released Courses
-
-* MakeCode Arcade Part 1: Block Coding
-
-### Courses in Development
-
-* MakeCode Arcade Part 2: Block Coding - Continued
-* MakeCode Arcade Part 3: JavaScript
-* MakeCode Arcade Part 4: JavaScript and HTML/CSS
-
-## Materials Included
-
-* Microsoft OneNote notebooks for students and teachers
-* PowerPoint Slides for framing lessons
-* Rubrics for Lessons
-* Sample Solutions to student activities
-* Teaching Guide, including Tips Videos
-* Multiple Choice Review Quiz/Test
-
-## Download Course Materials from MSIA
-
-Follow these instructions to get the course materials:
-
-1. [Sign in to MSIA](https://imagineacademy.info/index.php/educators) using your membership identity
-2. Navigate to [Computer Science Learning Path](https://member.imagineacademy.microsoft.com/learning-path#csps)
-3. Expand **Building Games** to select the download materials
+For any questions please check out the [Educator's Lounge](https://forum.makecode.com/c/educators-lounge/24) on our forum.

--- a/docs/courses/csintro4/about/teachers.md
+++ b/docs/courses/csintro4/about/teachers.md
@@ -1,8 +1,3 @@
-# Teachers -- COMING SOON
+# Teacher Resources
 
-The material for teachers is currently in production through Microsoft Imagine Academy (MSIA).
-This will include:
-
-* Microsoft OneNote notebooks for students and teachers
-* Sample solutions to all student activity
-* Teaching Guide (including videos)
+For any questions please check out the [Educator's Lounge](https://forum.makecode.com/c/educators-lounge/24) on our forum.


### PR DESCRIPTION
The links on these pages all either stall out or point to uncontrolled ads pages so just pointing to forum