### PR TITLE
Fix block highlight text in 'Which Button' activity

### DIFF
--- a/docs/concepts/which-button.md
+++ b/docs/concepts/which-button.md
@@ -69,7 +69,7 @@ info.startCountdown(10)
 
 ## {Step 6 @fullscreen}
 
-Get another ``||controller:on any button pressed||``, and drag it into the workspace. Change ``||controller:A||`` to ``||controller:B||``.
+Get another ``||controller:on A button pressed||``, and drag it into the workspace. Change ``||controller:A||`` to ``||controller:B||``.
 
 ```blocks
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {


### PR DESCRIPTION
The 'on any button' text still persists on this page. Change 'any' to 'A'.

Fixes #2360