### PR TITLE
[Stable 1.8] bump common packages to 9.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "typescript": "^4.2.3"
     },
     "dependencies": {
-        "pxt-common-packages": "9.4.11",
+        "pxt-common-packages": "9.4.13",
         "pxt-core": "7.4.27"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Includes these two fixes:

1. Fix for the collision bug for sprites where sprites get caught on tiles above them (https://github.com/microsoft/pxt-common-packages/commit/8293dac2025066d3141f32a76d9478ac57596016)
2. Fix for a couple of tilemap bugs around the load/unload events (https://github.com/microsoft/pxt-common-packages/commit/1c465ea78165960c21c5eba2ec60f0792e4923c0)