### PR TITLE
add pxt-raycasting to approved / preferred repos

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -20,7 +20,8 @@
             "microsoft/arcade-storytelling",
             "microsoft/arcade-background-scroll",
             "microsoft/arcade-character-animations",
-            "microsoft/arcade-tile-util"
+            "microsoft/arcade-tile-util",
+            "aqeeaqee/pxt-raycasting"
         ],
         "preferredRepos": [
             "adafruit/Circuit-Playground-Character-Icons",
@@ -37,7 +38,8 @@
             "microsoft/arcade-tile-util",
             "microsoft/arcade-storytelling",
             "microsoft/arcade-background-scroll",
-            "microsoft/arcade-character-animations"
+            "microsoft/arcade-character-animations",
+            "aqeeaqee/pxt-raycasting"
         ],
         "upgrades": {
             "microsoft/pxt-tilemaps": "min:v1.8.1",


### PR DESCRIPTION
They're finishing up the icon & maybe a few small edits in the docs, but it's a really fun extension and is used extensively on the forums.