### PR TITLE
Fix mistake in description of bump

### DIFF
--- a/docs/courses/csintro1/motion/overlap2.md
+++ b/docs/courses/csintro1/motion/overlap2.md
@@ -16,10 +16,10 @@ In this activity, the student will continue to work with:
 Having sprites bump rather than pass over each other is useful game behavior for a ``||sprites:kind||`` overlap event. One way to simulate a bump is:
 
 1. Move the sprite in the opposite direction after the overlap (we will make it bump backwards). The faster we bump, the farther we move away from the overlap object
-2. Stop the sprite
-    * Set ``||sprites:vx||`` and ``||sprites:vy||`` to 0
     * Change x position by (-1) \* (``||sprites:vx||``)
     * Change y position by (-1) \* (``||sprites:vy||``)
+2. Stop the sprite
+    * Set ``||sprites:vx||`` and ``||sprites:vy||`` to 0
 3. Shake the stationary object (cloud)
     * Move 1 pixel (in any direction)
     * ``||loops:pause||``


### PR DESCRIPTION
The bullet points were in the wrong position. Step 1 says to move the sprite backward, that's changing the x and y position. Step 2 says to stop the sprite, that's setting vx and vy to 0. [As written, vx and vy are being set to 0 first, so changing x and y by -1*vx and -1*vy would be changing them by 0, which is nonsensical.]