### PR TITLE
Changed say() to sayText()

### DIFF
--- a/docs/courses/csintro2/logic/intro.md
+++ b/docs/courses/csintro2/logic/intro.md
@@ -156,7 +156,7 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Cherry, function (sprite, otherS
     info.changeScoreBy(1)
     otherSprite.destroy()
     if (info.score() > 5) {
-        mySprite.say("Too many cherries")
+        mySprite.sayText("Too many cherries")
     }
 })
 mySprite = sprites.create(img`


### PR DESCRIPTION
We ran example 2 and it didn't completely work - we never saw the message about excess cherries. It turns out that the say() function is deprecated, so I replaced it with sayText(), which is not. [I just changed the JS code, but since the say block is the same regardless of whether say() or sayText() is used, that should be OK]