### PR TITLE
Bump kiosk game list

### DIFF
--- a/docs/GameList.json
+++ b/docs/GameList.json
@@ -103,7 +103,7 @@
       "highScoreMode": "None"
     },
     {
-      "id": "24350-12317-01060-00423",
+      "id": "99776-77448-58171-80239",
       "name": "Kickoff!",
       "description": "Time to practice your football throwing game! Coordinate plays and avoid defenders",
       "highScoreMode": "None"

--- a/docs/GameList.json
+++ b/docs/GameList.json
@@ -1,39 +1,112 @@
 {
-    "games": [
+  "games": [
     {
-        "id": "32777-59846-95775-11055",
-        "name": "Secure the river!",
-        "description": "This is a cooperative game, both players share the lives in this game. You must defeat all skeletons or you will lose a life. Hearts will replenish one life, while hitting ducks or fishes will drop one life.",
-        "highScoreMode": "SingleAscending"
+      "id": "31578-32581-92137-64320",
+      "name": "GalgaMulti",
+      "description": "Controlling a starship, both players will destroy the Galga forces, while avoiding enemies. Each player has 3 lives, game ends once a player runs out of lives.",
+      "highScoreMode": "SingleAscending"
     },
     {
-        "id": "13412-17300-80986-88577",
-        "name": "TicTacTwo!",
-        "description": "Ultimate battle between cats and dogs! The player who succeeds in placing three of their marks in a horizontal, vertical, or diagonal row is the winner as the best pet.",
-        "highScoreMode": "None"
+      "id": "32777-59846-95775-11055",
+      "name": "Secure the river!",
+      "description": "This is a cooperative game where both players share lives. You must defeat skeletons, collect hearts and avoid the ducks and fishes.",
+      "highScoreMode": "SingleAscending"
     },
     {
-        "id": "31578-32581-92137-64320",
-        "name": "GalgaMulti",
-        "description": "Controlling a starship, both players will destroy the Galga forces, while avoiding enemies. Each player has 3 lives, game ends once a player runs out of lives.",
-        "highScoreMode": "SingleAscending"
+      "id": "39705-92830-48491-01106",
+      "name": "Strawberry Slam",
+      "description": "Two strawberries battle it out in the kitchen to be the Shortcake Star!",
+      "highScoreMode": "SingleAscending"
     },
     {
-        "id": "69052-09321-39220-20264",
-        "name": "Blocky Boss Battle",
-        "description": "A challenging bullet shooter.",
-        "highScoreMode": "SingleAscending"
+      "id": "13412-17300-80986-88577",
+      "name": "TicTacTwo!",
+      "description": "Ultimate battle between cats and dogs! The player who succeeds in placing three of their marks in a horizontal, vertical, or diagonal row is the winner as the best pet.",
+      "highScoreMode": "None"
     },
     {
-        "id": "63642-20606-38782-29855",
-        "name": "Breakout",
-        "description": "Good luck getting that last one.",
-        "highScoreMode": "None"
+      "id": "69052-09321-39220-20264",
+      "name": "Blocky Boss Battle",
+      "description": "A test of reflexes! Avoid the blue stingers while sending fireballs at the boss!",
+      "highScoreMode": "SingleAscending"
     },
     {
-        "id": "58640-58387-80858-04361",
-        "name": "Jewel Raider",
-        "description": "It's not Tomb Raider.",
-        "highScoreMode": "None"
-    }    
-]}
+      "id": "07573-63879-62644-28924",
+      "name": "Asphodel follows directions",
+      "description": "Place arrows along the path to help Asphodel the witch find their way",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "24832-19682-40817-54648",
+      "name": "Pigeon: Deliverance",
+      "description": "Fly through the dangerous rooftops and ledges of New York City delivering messages!",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "19410-44885-95661-59850",
+      "name": "Save the Forest",
+      "description": "Fly your plane over the forest spraying water to put out the fires!",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "96744-30917-11312-43375",
+      "name": "Falling Duck",
+      "description": "Fly through the sky avoiding obstacles",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "50225-04801-24334-14778",
+      "name": "Space Destroyer",
+      "description": "Use the lasers on your spaceship to shoot falling asteroids!",
+      "highScoreMode": "SingleAscending"
+    },
+    {
+      "id": "27640-75402-47530-91242",
+      "name": "Hot Air Balloon",
+      "description": "Navigate your hot air balloon through the mountains avoiding birds and spaceships",
+      "highScoreMode": "SingleAscending"
+    },
+    {
+      "id": "91201-59331-72477-53174",
+      "name": "Bunny Hop!",
+      "description": "Help your bunny hop over obstacles as they run through the forest",
+      "highScoreMode": "SingleAscending"
+    },
+    {
+      "id": "91782-54072-13194-99228",
+      "name": "Caterpillar",
+      "description": "Eat the leaves to grow, but watch out for walls!",
+      "highScoreMode": "SingleAscending"
+    },
+    {
+      "id": "14111-27578-89085-17056",
+      "name": "Jewel Raider",
+      "description": "Adventure through levels collecting jewels and avoiding obstacles!",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "21784-44427-92956-37509",
+      "name": "Mouse Adventure",
+      "description": "Go on a mouse adventure in a haunted castle, battling bad guys, avoiding obstacles and collecting keys!",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "86980-49044-76449-93183",
+      "name": "Stack the Goats",
+      "description": "Build a tower of goats!",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "02651-16710-47798-38995",
+      "name": "Cave Explorer",
+      "description": "Explore multiple levels of caves deep within the earth, but watch out for those cave caterpillars!",
+      "highScoreMode": "None"
+    },
+    {
+      "id": "24350-12317-01060-00423",
+      "name": "Kickoff!",
+      "description": "Time to practice your football throwing game! Coordinate plays and avoid defenders",
+      "highScoreMode": "None"
+    }
+  ]
+}

--- a/kiosk/public/GameList.json
+++ b/kiosk/public/GameList.json
@@ -103,7 +103,7 @@
       "highScoreMode": "None"
     },
     {
-      "id": "24350-12317-01060-00423",
+      "id": "99776-77448-58171-80239",
       "name": "Kickoff!",
       "description": "Time to practice your football throwing game! Coordinate plays and avoid defenders",
       "highScoreMode": "None"

--- a/kiosk/public/GameList.json
+++ b/kiosk/public/GameList.json
@@ -103,7 +103,7 @@
       "highScoreMode": "None"
     },
     {
-      "id": "41564-92025-86448-02521",
+      "id": "24350-12317-01060-00423",
       "name": "Kickoff!",
       "description": "Time to practice your football throwing game! Coordinate plays and avoid defenders",
       "highScoreMode": "None"

--- a/kiosk/public/GameList.json
+++ b/kiosk/public/GameList.json
@@ -1,25 +1,25 @@
 {
   "games": [
     {
-      "id": "31578-32581-92137-64320", //Multiplayer
+      "id": "31578-32581-92137-64320",
       "name": "GalgaMulti",
       "description": "Controlling a starship, both players will destroy the Galga forces, while avoiding enemies. Each player has 3 lives, game ends once a player runs out of lives.",
       "highScoreMode": "SingleAscending"
     },
     {
-      "id": "32777-59846-95775-11055", //Multiplayer
+      "id": "32777-59846-95775-11055",
       "name": "Secure the river!",
       "description": "This is a cooperative game where both players share lives. You must defeat skeletons, collect hearts and avoid the ducks and fishes.",
       "highScoreMode": "SingleAscending"
     },
     {
-      "id": "39705-92830-48491-01106", //Multiplayer
+      "id": "39705-92830-48491-01106",
       "name": "Strawberry Slam",
       "description": "Two strawberries battle it out in the kitchen to be the Shortcake Star!",
       "highScoreMode": "SingleAscending"
     },
     {
-      "id": "13412-17300-80986-88577", //Multiplayer
+      "id": "13412-17300-80986-88577",
       "name": "TicTacTwo!",
       "description": "Ultimate battle between cats and dogs! The player who succeeds in placing three of their marks in a horizontal, vertical, or diagonal row is the winner as the best pet.",
       "highScoreMode": "None"
@@ -107,6 +107,6 @@
       "name": "Kickoff!",
       "description": "Time to practice your football throwing game! Coordinate plays and avoid defenders",
       "highScoreMode": "None"
-    },
+    }
   ]
 }


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/commit/0c0a075bbaf33cd570b640160856c21505c1debb, fix json & ran npm run deploy.

I guess there's no real need to run `npm run deploy` for this file as it just gets copied directly over... but at least worth pulling locally and testing before sending off so that works. I swapped the old version of pxt-kickoff I gave Jacqueline with a version that lets you pick which teams will play: https://arcade.makecode.com/99776-77448-58171-80239 (and e.g. handles setting alt colors if the same team is set for both sides).

@riknoll one thing that might be nice for menu extension would be something like 'reset scroll' -- I have it graying out the selected player team in the background while you select opposing team, and I lock to scroll speed 0 so it's not as distracting / doesn't move in the background, but if you do so while it's scrolled it will stay at that current offset. Right now I have it 'locked' by moving the selection up then down immediately to reset it:

![image](https://user-images.githubusercontent.com/5615930/175791166-bce183e4-8165-415c-86b3-226e7d573b25.png)

which I suppose is fine, maybe just drop it as a note in the docs of scroll speed or something
