### PR TITLE
Remove rimraf depdency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.9.2"
     },
     "scripts": {
-        "serve": "node node_modules/pxt-core/built/pxt.js serve"
+        "serve": "node node_modules/pxt-core/built/pxt.js serve",
+        "copy-sim": "node ./scripts/copyArcadeSim.js"
     }
 }

--- a/scripts/copyArcadeSim.js
+++ b/scripts/copyArcadeSim.js
@@ -1,13 +1,12 @@
 const fs = require("fs");
 const path = require("path");
-const rimraf = require("rimraf");
 
 const simModule = path.resolve("node_modules", "pxt-arcade-sim");
 const simSrc = path.resolve("..", "pxt-arcade-sim");
 
 if (fs.existsSync("node_modules")) {
     console.log("Deleting " + simModule)
-    rimraf.sync(simModule);
+    fs.rmSync(simModule, { recursive: true, force: true });
 }
 
 shallowCopy(simSrc, simModule);


### PR DESCRIPTION
Previously you had to install rimraf to run the copyArcadeSim script. This removes that secret dependecy now that node's fs lib supports recursively deleting directories.

Also added an npm script for convenience