### PR TITLE
fix gh-teacher-verif link

### DIFF
--- a/docs/courses/introcs.md
+++ b/docs/courses/introcs.md
@@ -51,7 +51,7 @@ The course materials include:
 
 #### Access Course Materials
 
-You must be a verified educator to download the course materials. Please create a GitHub Educator account, see the instructions here (https://makecode.com/github-teacher-verification).
+You must be a verified educator to download the course materials. Please create a GitHub Educator account, see the instructions here ([https://makecode.com/github-teacher-verification](https://makecode.com/github-teacher-verification)).
 
 Download the course materials: https://aka.ms/TEALSintroCS
 


### PR DESCRIPTION
Fix link to https://makecode.com/github-teacher-verification; the parsing is messed up so it counts the ) as part of the link and points at `https://makecode.com/github-teacher-verification)`

@ElizabethRiffle ^^ here's the fix, will take up to a day to clear cloud cache