### PR TITLE
Add pub hash to kiosk to open any share game

### DIFF
--- a/kiosk/src/App.tsx
+++ b/kiosk/src/App.tsx
@@ -35,8 +35,7 @@ function onHashChange() {
   const hash = window.location.hash;
   const match = /pub:((?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[a-zA-Z0-9]+))/.exec(hash);
   if (match) {
-    kioskSingleton.launchGame(match[1]);
-    kioskSingleton.lockMenu = true;
+    kioskSingleton.launchGame(match[1], true);
   }
 }
 

--- a/kiosk/src/App.tsx
+++ b/kiosk/src/App.tsx
@@ -13,6 +13,9 @@ function App() {
   const[state, setState] = useState(kioskSingleton.state);
 
   useEffect(() => {
+    window.onhashchange = onHashChange;
+    onHashChange();
+
     kioskSingleton.onNavigated = () => {
       setState(kioskSingleton.state);
     };
@@ -26,6 +29,15 @@ function App() {
     }
 
   return (<div />)
+}
+
+function onHashChange() {
+  const hash = window.location.hash;
+  const match = /pub:((?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[a-zA-Z0-9]+))/.exec(hash);
+  if (match) {
+    kioskSingleton.launchGame(match[1]);
+    kioskSingleton.lockMenu = true;
+  }
 }
 
 export default App;

--- a/kiosk/src/Models/Kiosk.ts
+++ b/kiosk/src/Models/Kiosk.ts
@@ -13,6 +13,7 @@ export class Kiosk {
     onGameSelected!: () => void;
     onNavigated!: () => void;
     state: KioskState = KioskState.MainMenu;
+    lockMenu = false;
 
     private readonly highScoresLocalStorageKey: string = "HighScores";
     private initializePromise: any;
@@ -144,7 +145,7 @@ export class Kiosk {
     }
 
     escapeGame(): void {
-        if (this.state !== KioskState.PlayingGame) { return; }
+        if (this.state !== KioskState.PlayingGame || this.lockMenu) { return; }
         this.gamepadManager.keyboardManager.clear();
         this.exitGame(KioskState.MainMenu);
     }


### PR DESCRIPTION
Adds a secret URL argument for opening any shared game in the kiosk experience. This works just like the pub URL argument in the editor:

```
https://arcade.makecode.com/kiosk#pub:xxxxx-xxxxx-xxxxx-xxxxx
```

The short form share id also works!

Using this argument will bypass the main menu and open the game directly in the kiosk game player. It also blocks you from escaping back to the main menu, so it's ideal for kiosk scenarios where you only want a single playable game.

The high score/leaderboard part of the kiosk is not supported in this mode