### PR TITLE
Add code ninjas tutorials as approved content

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -117,7 +117,8 @@
             "joylabz/makeymakey-makecode-arcade-extension": {
                 "preferred": true,
                 "tags": [ "Hardware" ]
-            }
+            },
+            "code-ninjas-home-office/game-building-session-tutorials": {}
         },
         "upgrades": {
             "microsoft/pxt-tilemaps": "min:v1.8.1",


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-arcade/issues/4944 -- i fixed tutorial approval in https://github.com/microsoft/pxt/pull/8977 so will only work after the next release (but will work in beta after this pr).

I suppose it might be worth adding a `tutorial-repo` flag in RepoData interface https://github.com/microsoft/pxt/blob/master/localtypings/pxtarget.d.ts#L52 so that tutorials only extensions don't show up in search, but that's pretty minor as they'd have to be searching for that extension's keywords in the first place. then when we get more approved external tutorials we can reuse the extension page for a tutorial search page if we wanted~

one of the tutorials https://arcade.makecode.com/beta#tutorial:code-ninjas-home-office/game-building-session-tutorials/find-the-ninja