### PR TITLE
upgrade to sim with nvda support

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.9.2
+          ref: v0.9.3
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.9.2
+          ref: v0.9.3
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pxt-core": "8.2.12"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.9.2"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.9.3"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",


### PR DESCRIPTION
Follow up of https://github.com/microsoft/pxt-arcade-sim/pull/70 to pick up changes that make canvas usable with screen reader.