### PR TITLE
_blank so hoc2022 buttons don't all open in same window

### DIFF
--- a/docs/hour-of-code-2022.html
+++ b/docs/hour-of-code-2022.html
@@ -122,7 +122,7 @@
             }
 
             function launchPage(url, tickEvent){
-                window.open(url, "blank");
+                window.open(url, "_blank");
                 window.pxtTickEvent(tickEvent);
             }
         </script>


### PR DESCRIPTION
with target="blank" it's currently opening in the same tab as it's a named target instead of just 'new tab' opt -- e.g. if you click a skillmap, then go back to hour of code page and click twitch icon, the skillmap tab will go to twitch.