### PR TITLE
bump to arcade-sim v0.9.7

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.9.6
+          ref: v0.9.7
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.9.6
+          ref: v0.9.7
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pxt-core": "8.3.4"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.9.6"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.9.7"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",


### PR DESCRIPTION
The latest arcade-sim introduced a regression **only when pointer-events is enabled**. Basically preventing the event bubbling breaks selecting the canvas using the mouse.

https://github.com/microsoft/pxt-arcade-sim/commit/148e538b56ae70d8c93c756becf4b5cef601118d