### PR TITLE
match sound effect editor colors to music category

### DIFF
--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -119,3 +119,7 @@
 --------------------*/
 
 @greenScreenBlockColor: #20BF6B;
+
+
+@soundEffectHeaderColor: #E30FC0;
+@soundPreviewBackgroundColor: #F7EEF5;

--- a/theme/style.less
+++ b/theme/style.less
@@ -73,6 +73,14 @@
     color: @white;
 }
 
+.common-radio-group.common-radio-buttons .common-radio-choice.selected {
+    color: @soundEffectHeaderColor;
+}
+
+.draggable-graph-path {
+    stroke: @soundEffectHeaderColor;
+}
+
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5058

![image](https://user-images.githubusercontent.com/13754588/193157270-81cc8c51-9809-4144-8160-b9188b346789.png)

I definitely prefer the orange of the micro:bit music category but this looks okay too