### PR TITLE
Removed titled img references

### DIFF
--- a/docs/skillmap/balloon/balloon4.md
+++ b/docs/skillmap/balloon/balloon4.md
@@ -203,9 +203,9 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Released, function () {
         myMouse2.setImage(assets.image`mouse2-up`)
 })
@@ -271,11 +271,11 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Released, function () {
-        myMouse2.setImage(assets.image`mouse2-up`)
+        myMouse2.setImage(img`.`)
 })
 ```
 
@@ -323,12 +323,12 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
     info.player2.changeScoreBy(1)
-    myMouse2.setImage(assets.image`mouse2-down`)
+    myMouse2.setImage(img`.`)
     scaling.scaleByPixels(myBalloon2, 1, ScaleDirection.Uniformly, ScaleAnchor.Bottom)
 })
 ```
@@ -400,11 +400,11 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Released, function () {
-        myMouse2.setImage(assets.image`mouse2-up`)
+        myMouse2.setImage(img`.`)
 })
 ```
 

--- a/docs/skillmap/mole/mole1.md
+++ b/docs/skillmap/mole/mole1.md
@@ -249,7 +249,7 @@ When you're ready, click **Done** to return to the skillmap so you can add a rub
 
 
 ```blockconfig.global
-let myMole = sprites.create(img'.', SpriteKind.Enemy)
+let myMole = sprites.create(img`.`, SpriteKind.Enemy)
 
 game.onUpdateInterval(1000, function () {
 sprites.move_to_random_hole_on_grid(myMole)

--- a/docs/skillmap/mole/mole2.md
+++ b/docs/skillmap/mole/mole2.md
@@ -281,7 +281,7 @@ When you're ready, click **Done** to return to the skillmap so you can add sound
 
 
 ```blockconfig.global
-let myHammer = sprites.create(assets.image`hammer`, SpriteKind.Player)
+let myHammer = sprites.create(img`.`, SpriteKind.Player)
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) { info.changeScoreBy(1) })
 ```
 

--- a/docs/skillmap/mole/mole3.md
+++ b/docs/skillmap/mole/mole3.md
@@ -229,7 +229,7 @@ When you're ready, click **Done** to return to the skillmap to turn it into a mu
 let myHammer: Sprite = null
 animation.runImageAnimation(
 myHammer,
-assets.animation`hammerAnimation`,
+[img`.`],
 50,
 false
 )

--- a/docs/test/skillmap/balloon/balloon4.md
+++ b/docs/test/skillmap/balloon/balloon4.md
@@ -203,11 +203,11 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Released, function () {
-        myMouse2.setImage(assets.image`mouse2-up`)
+        myMouse2.setImage(img`.`)
 })
 ```
 
@@ -271,11 +271,11 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Released, function () {
-        myMouse2.setImage(assets.image`mouse2-up`)
+        myMouse2.setImage(img`.`)
 })
 ```
 
@@ -323,12 +323,12 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
     info.player2.changeScoreBy(1)
-    myMouse2.setImage(assets.image`mouse2-down`)
+    myMouse2.setImage(img`.`)
     scaling.scaleByPixels(myBalloon2, 1, ScaleDirection.Uniformly, ScaleAnchor.Bottom)
 })
 ```
@@ -400,11 +400,11 @@ hint~
 
 
 ```blockconfig.local
-let myMouse2 = sprites.create(assets.image`balloon-2`, SpriteKind.Mouse)
+let myMouse2 = sprites.create(img`.`, SpriteKind.Mouse)
 myMouse2.setPosition(110, 93)
-myMouse2.setImage(assets.image`mouse2-down`)
+myMouse2.setImage(img`.`)
 controller.B.onEvent(ControllerButtonEvent.Released, function () {
-        myMouse2.setImage(assets.image`mouse2-up`)
+        myMouse2.setImage(img`.`)
 })
 ```
 

--- a/docs/test/skillmap/mole/mole1.md
+++ b/docs/test/skillmap/mole/mole1.md
@@ -249,7 +249,7 @@ When you're ready, click **Done** to return to the skillmap so you can add a rub
 
 
 ```blockconfig.global
-let myMole = sprites.create(img'.', SpriteKind.Enemy)
+let myMole = sprites.create(img`.`, SpriteKind.Enemy)
 
 game.onUpdateInterval(1000, function () {
 sprites.move_to_random_hole_on_grid(myMole)

--- a/docs/test/skillmap/mole/mole2.md
+++ b/docs/test/skillmap/mole/mole2.md
@@ -281,7 +281,7 @@ When you're ready, click **Done** to return to the skillmap so you can add sound
 
 
 ```blockconfig.global
-let myHammer = sprites.create(assets.image`hammer`, SpriteKind.Player)
+let myHammer = sprites.create(img`.`, SpriteKind.Player)
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) { info.changeScoreBy(1) })
 ```
 

--- a/docs/test/skillmap/mole/mole3.md
+++ b/docs/test/skillmap/mole/mole3.md
@@ -229,11 +229,11 @@ When you're ready, click **Done** to return to the skillmap to claim your badge 
 let myHammer: Sprite = null
 animation.runImageAnimation(
 myHammer,
-assets.animation`hammerAnimation`,
+[img`.`],
 50,
 false
 )
-myHammer = sprites.create(assets.image`hammer`, SpriteKind.Player)
+myHammer = sprites.create(img`.`, SpriteKind.Player)
 sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) { info.changeScoreBy(1) })
 ```
 

--- a/docs/test/skillmap/mole/mole4.md
+++ b/docs/test/skillmap/mole/mole4.md
@@ -328,7 +328,7 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSp
     music.knock.play()
         animation.runImageAnimation(
         myHammer,
-        assets.animation`hammerAnimation`,
+        [img`.`],
         50,
         false
         )


### PR DESCRIPTION
This is mostly an FYI, even though it touches non-test files.

Accidentally used img'.' instead of img`.`, which messed up my default blocks. 