### PR TITLE
Bumping arcade-sim 0.10.3

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.9.8
+          ref: v0.10.3
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.9.8
+          ref: v0.10.3
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pxt-core": "8.3.9"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.9.8"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.10.3"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",


### PR DESCRIPTION
Just 3 check-ins between 0.9.8 & 0.10.3 -> https://github.com/microsoft/pxt-arcade-sim/commits/master seems ok to just point the latest.

If you think it is risk, I can port to the 0.9 stable channel in arcade-sim before I port here.