### PR TITLE
Add multiplayer button to the share page

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -27,6 +27,7 @@
                         <a id="editCodeButton" href="/@versionsuff@#pub:@id@" class="ui mini button landscape only" role="menuitem">Edit Code</a>
                     </div>
                     <div class="page-header-item no-grow">
+                        <button id="multiplayer-share-button" class="ui mini default button" role="menuitem" style="display: none">Play online with friends</button>
                         <a href="https://makecode.com/org" title="Go to Microsoft MakeCode" aria-label="Microsoft MakeCode Logo" role="menuitem" target="blank" rel="noopener" class="ui item logo organization no-select">
                             <img class="ui logo portrait hide" src="./static/Microsoft-logo_rgb_c-gray.png" alt="Microsoft MakeCode Logo">
                             <img class="ui mini image portrait only" src="./static/Microsoft-logo_rgb_c-gray-square.png" alt="Microsoft MakeCode Logo">
@@ -145,6 +146,7 @@
             var editorEmbedURL = "/@versionsuff@#sandbox:@id@";
             var showCodeButton = document.getElementById("show-code-button");
             var editCodeButton = document.getElementById("editCodeButton");
+            var multiplayerShareButton = document.getElementById("multiplayer-share-button");
             var embedContainer = document.getElementById("embed-frame");
 
             var builtSimJSPromise = Promise.resolve(undefined);
@@ -189,6 +191,14 @@
                 }
                 isGame = !isGame;
             });
+
+            multiplayerShareButton.addEventListener("click", function() {
+                window.pxtTickEvent('share.multiplayerShareClick', { target: "arcade" });
+                const domain = pxt.BrowserUtils.isLocalHostDev() ? "http://localhost:3000" : "";
+                const multiplayerHostUrl = `${domain}${pxt.webConfig.relprefix}multiplayer?host=@id@`;
+
+                window.open(multiplayerHostUrl, "_blank");
+            })
 
             var shareLinkIsApproved = false;
 
@@ -268,6 +278,11 @@
                             if (!builtSimJS)
                                 builtSimJSPromise = Promise.resolve(built);
                             console.log('simulator started...');
+
+                            if (built.parts.indexOf("multiplayer" !== -1)) {
+                                window.pxtTickEvent('share.isMultiplayerGame', { target: "arcade" });
+                                multiplayerShareButton.style.display = "block";
+                            }
                         });
                     });
                 }, 0);

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -27,7 +27,7 @@
                         <a id="editCodeButton" href="/@versionsuff@#pub:@id@" class="ui mini button landscape only" role="menuitem">Edit Code</a>
                     </div>
                     <div class="page-header-item no-grow">
-                        <button id="multiplayer-share-button" class="ui mini default button" role="menuitem" style="display: none">Play online with friends</button>
+                        <button id="multiplayer-share-button" class="ui mini default button" role="menuitem" style="display: none">Host Game</button>
                         <a href="https://makecode.com/org" title="Go to Microsoft MakeCode" aria-label="Microsoft MakeCode Logo" role="menuitem" target="blank" rel="noopener" class="ui item logo organization no-select">
                             <img class="ui logo portrait hide" src="./static/Microsoft-logo_rgb_c-gray.png" alt="Microsoft MakeCode Logo">
                             <img class="ui mini image portrait only" src="./static/Microsoft-logo_rgb_c-gray-square.png" alt="Microsoft MakeCode Logo">


### PR DESCRIPTION
PR 3 of 3 for automatically detecting if a game is multiplayer at compile time.

This PR relies on https://github.com/microsoft/pxt-common-packages/pull/1381 and https://github.com/microsoft/pxt/pull/9161

Adds a multiplayer button to the share page. Currently looks like this:

![image](https://user-images.githubusercontent.com/13754588/199123096-1161e6a1-d1ef-445a-aa7f-da604eac76a9.png)


...and could obviously do with a design pass. The button shows up as soon as the compile has finished. If we eventually end up moving the compile to the server side, we need to make sure this metadata is sent down (@aznhassan FYI)