### PR TITLE
Add showMultiplayerShare to balloon test skillmap

### DIFF
--- a/docs/test/skillmap/balloon.md
+++ b/docs/test/skillmap/balloon.md
@@ -71,6 +71,7 @@
 * type: certificate
 * url: /static/skillmap/certificates/balloon-cert.pdf
 * imageUrl: /static/skillmap/certificates/balloon-cert.png
+* showMultiplayerShare: true
 * position: 2 3
 * actions:
     * map: [Finish the Last Level](/skillmap/balloon)


### PR DESCRIPTION
Turning on the option to have the multiplayer share callout appear in the completion modal for the balloon skillmap