### PR TITLE
Kiosk: using full path for scan endpoint

### DIFF
--- a/kiosk/src/Components/AddingGame.tsx
+++ b/kiosk/src/Components/AddingGame.tsx
@@ -16,7 +16,7 @@ const AddingGame: React.FC<IProps> = ({ kiosk }) => {
     const [renderQRCode, setRenderQRCode] = useState(true);
     const [menuButtonSelected, setMenuButtonState] = useState(false);
     const [qrCodeButtonSelected, setQrButtonState] = useState(false);
-    const kioskCodeUrl = isLocal() ? "http://localhost:3000/static/kiosk/" : "/kiosk";
+    const kioskCodeUrl = isLocal() ? "http://localhost:3000/static/kiosk/" : "https://arcade.makecode.com/kiosk";
 
     const updateLoop = () => {
         if (!menuButtonSelected && kiosk.gamepadManager.isDownPressed()) {


### PR DESCRIPTION
In production, when scanning the QR code, the path wouldn't fully resolve itself because of how I coded the URL into the qrcode generator. I changed the production path to fully include arcade.makecode.com so scanning the qr code reaches the correct endpoint. 