### PR TITLE
Kiosk: clean state for kiosk, will not use game list

### DIFF
--- a/kiosk/src/App.tsx
+++ b/kiosk/src/App.tsx
@@ -9,7 +9,9 @@ import AddingGame from './Components/AddingGame';
 import ScanQR from './Components/ScanQR';
 import QrSuccess from './Components/QrSuccess';
 
-const kioskSingleton: Kiosk = new Kiosk();
+const firstHash = window.location.pathname;
+const clean = /--clean/.exec(firstHash);
+const kioskSingleton: Kiosk = new Kiosk(!!clean);
 kioskSingleton.initialize().catch(error => alert(error));
 
 function App() {
@@ -46,7 +48,7 @@ function onHashChange() {
   const addGame = /add-game:((?:[a-zA-Z0-9]{6}))/.exec(hash);
   if (match) {
     kioskSingleton.launchGame(match[1], true);
-  } else if (addGame){
+  } else if (addGame) {
     kioskSingleton.navigate(KioskState.ScanQR);
   }
 }

--- a/kiosk/src/Components/GameList.tsx
+++ b/kiosk/src/Components/GameList.tsx
@@ -119,7 +119,7 @@ const GameList: React.FC<IProps> = ({ kiosk, buttonSelected }) => {
     if (!kiosk.games || !kiosk.games.length) {
         return(
         <div>
-            <p>Could not fetch kiosk games</p>
+            <p>Currently no kiosk games</p>
         </div>);
     }
 


### PR DESCRIPTION
In a classroom setting, we might not want the kiosk to be populated with the games that we have from the game list. We should allow the kiosk to only be full of students' games.

Now, if you use the --clean flag in the url, the kiosk will be completely empty until games are added.

If you get rid of the flag, the games from the game list and the games that the users have added will be on the kiosk. 

Needed for @kiki-lee's classroom visits this week.