### PR TITLE
Kiosk: accepting all forms of a share link

### DIFF
--- a/kiosk/src/Components/ScanQR.tsx
+++ b/kiosk/src/Components/ScanQR.tsx
@@ -26,11 +26,16 @@ const ScanQR: React.FC<IProps> = ({ kiosk }) => {
     const checkUrl = async () => {
         const input = document.getElementById("kiosk-share-link") as HTMLInputElement;
         const inputValue = input.value;
-        const shareLink = /(https:\/\/)((arcade\.makecode\.com\/)|(makecode\.com\/))((?:S\d{5}-\d{5}-\d{5}-\d{5})|(?:_[a-zA-Z0-9]+))/.exec(inputValue);
+        const shareLink = /^(https:\/\/)((arcade\.makecode\.com\/)|(makecode\.com\/))((?:S\d{5}-\d{5}-\d{5}-\d{5})$|(?:_[a-zA-Z0-9]+)$)/.exec(inputValue);
+        const shareCode = /(^(?:S\d{5}-\d{5}-\d{5}-\d{5})$|^(?:_[a-zA-Z0-9]{12})$)/.exec(inputValue);
         let shareId;
         if (shareLink) {
-            setLinkError(false);
             shareId = /\/([^\/]+)\/?$/.exec(inputValue)?.[1];
+        } else if (shareCode) {
+            shareId = shareCode?.[1];
+        }
+        if (shareId) {
+            setLinkError(false);
             try {
                 await addGameToKioskAsync(kioskId, shareId);
                 kiosk.navigate(KioskState.QrSuccess);


### PR DESCRIPTION
The input field for a game's share link when adding a game to kiosk now accepts all forms of a share link.

Examples:
https://arcade.makecode.com/S32800-39924-12945-26540
https://makecode.com/_f0jhEb99UFkP
S32800-39924-12945-26540
_f0jhEb99UFkP

I've also updated the regex so the input will only send a request to the backend if **only** the link is in the field. This guards from people trying to add extra, unnecessary characters/sending malicious input.

Closes https://github.com/microsoft/pxt-arcade/issues/5408