### PR TITLE
bump pxt-common-packages > 10.3.5, pxt-core > 8.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "10.3.4",
-        "pxt-core": "8.5.6"
+        "pxt-common-packages": "10.3.5",
+        "pxt-core": "8.5.7"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.10.4"


### PR DESCRIPTION
bumping to pick up custom multiplayer user icons / reactions changes (+ others)

(and here's one of the test programs that sets a few icons https://arcade.makecode.com/S53662-77802-01315-54005)