### PR TITLE
Share to kiosk field added to app theme in pxtarget.json

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -646,7 +646,8 @@
         "immersiveReader": true,
         "tutorialCodeValidation": true,
         "multiplayer": true,
-        "songEditor": true
+        "songEditor": true,
+        "shareToKiosk": true
     },
     "queryVariants": {
         "skillsMap=1": {


### PR DESCRIPTION
Needed to add this field so that the share to kiosk button would not be available on micro:bit and Minecraft targets. 

Tied to https://github.com/microsoft/pxt/pull/9297