### PR TITLE
bump pxt->8.5.16, pxt-c-p->10.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "10.3.7",
-        "pxt-core": "8.5.14"
+        "pxt-common-packages": "10.3.8",
+        "pxt-core": "8.5.16"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.10.5"


### PR DESCRIPTION
pick up multiplayer changes, notably enabling XOR diff which we have to test a bit further