### PR TITLE
Categorize builtin extensions in the extension browser

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -62,7 +62,7 @@
             },
             "jwunderl/pxt-status-bar": {
                 "preferred": true,
-                "tags": [ "Sprites", "Info" ]
+                "tags": [ "Sprites" ]
             },
             "microsoft/pxt-settings-blocks": {
                 "preferred": true,
@@ -70,7 +70,7 @@
             },
             "microsoft/arcade-sprite-data": {
                 "preferred": true,
-                "tags": [ "Utility", "Info" ],
+                "tags": [ "Utility" ],
                 "upgrades": "min:v0.0.6"
             },
             "microsoft/arcade-grid": {
@@ -83,7 +83,7 @@
             },
             "microsoft/arcade-timers": {
                 "preferred": true,
-                "tags": [ "Utility", "Game" ]
+                "tags": [ "Utility" ]
             },
             "microsoft/arcade-text": {
                 "preferred": true,
@@ -136,7 +136,7 @@
             },
             "multiplayer": {
                 "preferred": true,
-                "tags": [ "Utility", "Controller", "Game", "Info", "Sprites" ]
+                "tags": [ "Utility", "Controller", "Sprites" ]
             },
             "sprite-scaling": {
                 "preferred": true,
@@ -172,7 +172,7 @@
             },
             "feather": {
                 "preferred": true,
-                "tags": [ "Hardware" ]
+                "tags": [ "Hardware", "Controller" ]
             }
         },
         "upgrades": {

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -121,6 +121,60 @@
             "code-ninjas-home-office/game-building-session-tutorials": {},
             "microsoft/arcade-carnival": {}
         },
+        "builtinExtensionsLib": {
+            "controller": {
+                "preferred": true,
+                "tags": [ "Utility" ]
+            },
+            "animation": {
+                "preferred": true,
+                "tags": [ "Sprites" ]
+            },
+            "multiplayer": {
+                "preferred": true,
+                "tags": [ "Utility" ]
+            },
+            "sprite-scaling": {
+                "preferred": true,
+                "tags": [ "Sprites" ]
+            },
+            "corgio": {
+                "preferred": true,
+                "tags": [ "Sprites" ]
+            },
+            "darts": {
+                "preferred": true,
+                "tags": [ "Sprites" ]
+            },
+            "edge-connector": {
+                "preferred": true,
+                "tags": [ "Hardware" ]
+            },
+            "light": {
+                "preferred": true,
+                "tags": [ "Hardware" ]
+            },
+            "radio-broadcast": {
+                "preferred": true,
+                "tags": [ "Utility"]
+            },
+            "servo": {
+                "preferred": true,
+                "tags": [ "Hardware" ]
+            },
+            "sevenseg": {
+                "preferred": true,
+                "tags": [ "Utility" ]
+            },
+            "color-coded-tilemap": {
+                "preferred": true,
+                "tags": [ "Utility"]
+            },
+            "feather": {
+                "preferred": true,
+                "tags": [ "Hardware"]
+            }
+        },
         "upgrades": {
             "microsoft/pxt-tilemaps": "min:v1.8.1",
             "microsoft/arcade-sprite-data": "min:v0.0.6"

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -168,11 +168,11 @@
             },
             "color-coded-tilemap": {
                 "preferred": true,
-                "tags": [ "Utility"]
+                "tags": [ "Utility" ]
             },
             "feather": {
                 "preferred": true,
-                "tags": [ "Hardware"]
+                "tags": [ "Hardware" ]
             }
         },
         "upgrades": {

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -53,7 +53,8 @@
                 "tags": [ "Hardware" ]
             },
             "jwunderl/pxt-button-combos": {
-                "preferred": true
+                "preferred": true,
+                "tags": [ "Controller" ]
             },
             "jwunderl/pxt-color": {
                 "preferred": true,
@@ -61,7 +62,7 @@
             },
             "jwunderl/pxt-status-bar": {
                 "preferred": true,
-                "tags": [ "Sprites" ]
+                "tags": [ "Sprites", "Info" ]
             },
             "microsoft/pxt-settings-blocks": {
                 "preferred": true,
@@ -69,17 +70,20 @@
             },
             "microsoft/arcade-sprite-data": {
                 "preferred": true,
-                "tags": [ "Utility" ],
+                "tags": [ "Utility", "Info" ],
                 "upgrades": "min:v0.0.6"
             },
-            "microsoft/arcade-grid": { "preferred": true },
-            "microsoft/arcade-minimap": {
+            "microsoft/arcade-grid": {
                 "preferred": true,
                 "tags": [ "Sprites" ]
             },
+            "microsoft/arcade-minimap": {
+                "preferred": true,
+                "tags": [ "Sprites", "Visual Effects" ]
+            },
             "microsoft/arcade-timers": {
                 "preferred": true,
-                "tags": [ "Utility" ]
+                "tags": [ "Utility", "Game" ]
             },
             "microsoft/arcade-text": {
                 "preferred": true,
@@ -124,19 +128,19 @@
         "builtinExtensionsLib": {
             "controller": {
                 "preferred": true,
-                "tags": [ "Utility" ]
+                "tags": [ "Utility", "Controller" ]
             },
             "animation": {
                 "preferred": true,
-                "tags": [ "Sprites" ]
+                "tags": [ "Sprites", "Visual Effects" ]
             },
             "multiplayer": {
                 "preferred": true,
-                "tags": [ "Utility" ]
+                "tags": [ "Utility", "Controller", "Game", "Info", "Sprites" ]
             },
             "sprite-scaling": {
                 "preferred": true,
-                "tags": [ "Sprites" ]
+                "tags": [ "Sprites", "Visual Effects" ]
             },
             "corgio": {
                 "preferred": true,
@@ -163,10 +167,6 @@
                 "tags": [ "Hardware" ]
             },
             "sevenseg": {
-                "preferred": true,
-                "tags": [ "Utility" ]
-            },
-            "color-coded-tilemap": {
                 "preferred": true,
                 "tags": [ "Utility" ]
             },


### PR DESCRIPTION
Depends on https://github.com/microsoft/pxt/pull/9328
Closes https://github.com/microsoft/pxt-arcade/issues/4992
I also added more tags for both the builtin extensions and the approved repos.