### PR TITLE
bump arcade sim to v0.11.1

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.10.6
+          ref: v0.11.1
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.10.6
+          ref: v0.11.1
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pxt-core": "8.5.22"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.10.6"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.1"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",


### PR DESCRIPTION
pick up https://github.com/microsoft/pxt-arcade-sim/pull/86

I guess it's probably fine either way to port this or not unless you have a preference @eanders-ms ? as they can just use `/beta--run?id=...`