### PR TITLE
Kiosk: new description in the index html file

### DIFF
--- a/docs/kiosk.html
+++ b/docs/kiosk.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/static/kiosk/favicon.ico"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="theme-color" content="#000000"/>
-    <meta name="description" content="Web site created using create-react-app"/>
+    <meta name="description" content="MakeCode Arcade Kiosk mode. Showcase games made on Microsoft MakeCode Arcade in a carousel list."/>
     <link rel="apple-touch-icon" href="/static/kiosk/logo192.png"/>
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/kiosk/public/index.html
+++ b/kiosk/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="MakeCode Arcade Kiosk mode. Showcase games made on Microsoft MakeCode Arcade in a carousel list."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
We don't want the description for kiosk to be the default "create-react-app" phrase. The updated text is similar to what is said in the kiosk docs.