### PR TITLE
Add main reference page for 'sevenseg`

### DIFF
--- a/libs/sevenseg/docs/reference/sevenseg.md
+++ b/libs/sevenseg/docs/reference/sevenseg.md
@@ -1,0 +1,27 @@
+# SevenSeg
+
+Create and use 7-segment digit and counter displays.
+
+## Counters
+
+```cards
+sevenseg.createCounter(SegmentStyle.Thick, SegmentScale.Full, 2)
+sevenseg.createCounter().setDigitColor(0)
+```
+
+## Digits
+
+```cards
+sevenseg.createDigit(SegmentStyle.Thick, 0)
+sevenseg.createDigit().setDigitColor(0)
+sevenseg.createDigit().setRadix(SegmentScall.Half)
+sevenseg.createDigit().setScale(SegmentScall.Half)
+```
+
+## See also
+
+[create counter](/reference/sevenseg/create-counter), [create digit](/reference/sevenseg/create-digit)
+
+```package
+sevenseg
+```


### PR DESCRIPTION
Include the top level `./reference/sevenseg.md` page as a destination for the "Learn More" line in Extensions.

Closes #5580