### PR TITLE
Enable arabic in /beta

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -553,6 +553,7 @@
         "selectLanguage": true,
         "availableLocales": [
             "en",
+            "ar",
             "zh-CN",
             "zh-TW",
             "de",


### PR DESCRIPTION
It has 3 parts for every language: 
1.	UI:       Editor UI strings (like new project or tutorial text ). This is common across all the editors we have. 
2.	Core:  All the core blocks which are loaded with the default project. This one is the most import one. 
3.	Blocks:  These are additional blocks such as servo, but also include some of the microbit specific strings for download etc.  

1st & 2nd one is the most important. 

context	| language | 	translated% |	approved%	| phrases |	translated|	Approved
---|---|---|---|---|-------|---|
ui |	ar |	91%	| 46% |	1923 |    	1767 |    	900
core | 	ar |	51%	| 51%	| 56     | 	29	| 29
blocks	| ar |	32%	| 28% |	6526 |    	2113 |    	1831

I see only 51% in core strings.  This is just one file in the attached.

2925	arcade/core-strings.json	ar	56	29	29

Plan is to translate this in parallel.
