### PR TITLE
Add project templates for VS code extension

### DIFF
--- a/docs/js-templates.md
+++ b/docs/js-templates.md
@@ -1,0 +1,22 @@
+# JavaScript project templates
+
+These templates show up in the Visual Studio Code extension when you use the "Create Empty Project" command.
+
+## Fun stuff
+
+```codecard
+[
+    {
+        "name": "Platformer Template",
+        "description": "A simple platformer project with a Tilemap and enemies",
+        "url": "https://makecode.com/_2fPCkKC1k4hM",
+        "cardType": "sharedExample"
+    },
+    {
+        "name": "Flapping Bird Template",
+        "description": "Classic arcade-style gameplay with an Animation and dynamically drawn Sprites",
+        "url": "https://makecode.com/_fHvMM6fXvW9i",
+        "cardType": "sharedExample"
+    }
+]
+```


### PR DESCRIPTION
These will be consumed by my upcoming VS Code extension changes. They're defined as a gallery, but won't be in the homescreen. We can choose to surface them later if we feel like it.