### PR TITLE
Use relative urls for multiplayer launch points

### DIFF
--- a/docs/multiplayer-games.md
+++ b/docs/multiplayer-games.md
@@ -11,9 +11,9 @@ Try these multiplayer games with your friends!
 * actionIcon: xicon multiplayer
 * imageUrl: /static/multiplayer/perfect-fit.png
 * largeImageUrl: /static/multiplayer/perfect-fit.gif
-* url: https://arcade.makecode.com/---multiplayer?host=_bz3CCuWFiepH
+* url: /--multiplayer?host=_bz3CCuWFiepH
 * cardType: link
-* otherAction: https://arcade.makecode.com/_bz3CCuWFiepH, , sharedExample
+* otherAction: /_bz3CCuWFiepH, , sharedExample
 ---
 * name: Galga
 * description: Controlling a starship, up to 4 players can help destroy the Galga forces, while avoiding enemies. Each player has 3 lives, last player alive wins the game!
@@ -21,9 +21,9 @@ Try these multiplayer games with your friends!
 * actionIcon: xicon multiplayer
 * imageUrl: /static/multiplayer/galga.png
 * largeImageUrl: /static/multiplayer/galga.gif
-* url: https://arcade.makecode.com/---multiplayer?host=_C71PmfFaYDm2
+* url: /--multiplayer?host=_C71PmfFaYDm2
 * cardType: link
-* otherAction: https://arcade.makecode.com/_C71PmfFaYDm2, , sharedExample
+* otherAction: /_C71PmfFaYDm2, , sharedExample
 ---
 * name: Arrow Battle
 * description: 2-4 people can play to see who's the quickest at matching the arrow directions.
@@ -31,9 +31,9 @@ Try these multiplayer games with your friends!
 * actionIcon: xicon multiplayer
 * imageUrl: /static/multiplayer/arrow-battle.gif
 * largeImageUrl: /static/multiplayer/arrow-battle-large.gif
-* url: https://arcade.makecode.com/---multiplayer?host=_dCP7f8c3q5PJ
+* url: /--multiplayer?host=_dCP7f8c3q5PJ
 * cardType: link
-* otherAction: https://arcade.makecode.com/_dCP7f8c3q5PJ, , sharedExample
+* otherAction: /_dCP7f8c3q5PJ, , sharedExample
 ---
 * name: Tag
 * description: When you're it, tag a friend and they will lose a life. Be careful, if time runs out you'll lose a life instead! Up to 4 people can play.
@@ -41,9 +41,9 @@ Try these multiplayer games with your friends!
 * actionIcon: xicon multiplayer
 * imageUrl: /static/multiplayer/tag.png
 * largeImageUrl: /static/multiplayer/tag.gif
-* url: https://arcade.makecode.com/---multiplayer?host=_cvxPm1WesYyi
+* url: /--multiplayer?host=_cvxPm1WesYyi
 * cardType: link
-* otherAction: https://arcade.makecode.com/_cvxPm1WesYyi, , sharedExample
+* otherAction: /_cvxPm1WesYyi, , sharedExample
 ---
 * name: Horse Race
 * description: Up to 4 players race their horse to the finish line.
@@ -51,9 +51,9 @@ Try these multiplayer games with your friends!
 * actionIcon: xicon multiplayer
 * imageUrl: /static/multiplayer/horse-race.png
 * largeImageUrl: /static/multiplayer/horse-race.gif
-* url: https://arcade.makecode.com/---multiplayer?host=_1DogpPTpb8fK
+* url: /--multiplayer?host=_1DogpPTpb8fK
 * cardType: link
-* otherAction: https://arcade.makecode.com/_1DogpPTpb8fK, , sharedExample
+* otherAction: /_1DogpPTpb8fK, , sharedExample
 ---
 * name: Painting Together
 * description: Up to 4 people can paint together. Paint by holding down the A button and moving the arrow keys. Change the brush size by clicking the B button.
@@ -61,8 +61,8 @@ Try these multiplayer games with your friends!
 * actionIcon: xicon multiplayer
 * imageUrl: /static/multiplayer/painting.png
 * largeImageUrl: /static/multiplayer/painting.gif
-* url: https://arcade.makecode.com/---multiplayer?host=_FdYfDwixRTAw
+* url: /--multiplayer?host=_FdYfDwixRTAw
 * cardType: link
-* otherAction: https://arcade.makecode.com/_FdYfDwixRTAw, , sharedExample
+* otherAction: /_FdYfDwixRTAw, , sharedExample
 
 ### ~

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -574,7 +574,7 @@
         "homeScreenHero": {
             "imageUrl": "/static/hero-gallery/multiplayer-banner.png",
             "name": "Multiplayer Games!",
-            "url": "https://arcade.makecode.com/--multiplayer",
+            "url": "/--multiplayer",
             "buttonLabel": "Try Now",
             "description": "Multiplayer Games!",
             "cardType": "link"


### PR DESCRIPTION
@jwunderl do you know if this will this work?
When I click a multiplayer launch url, I want it to open on the current domain, which might be staging, a custom target, or the production site, etc.