### PR TITLE
Add open in vs code flag and set true

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -656,7 +656,8 @@
         "shareToKiosk": true,
         "tours": {
             "editor": "/tours/editor-tour"
-        }
+        },
+        "showOpenInVscode": true
     },
     "queryVariants": {
         "skillsMap=1": {


### PR DESCRIPTION
Depends on https://github.com/microsoft/pxt/pull/9480

I created a flag in pxt because we don't want the `Open in VS Code` button showing up in microbit. Adding the flag and setting to true for Arcade to keep the current behavior: The button shows while in JavaScript.