### PR TITLE
Hide "Replace my Code" unless we're in a skillmap

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -658,14 +658,16 @@
         "tours": {
             "editor": "/tours/editor-tour"
         },
-        "showOpenInVscode": true
+        "showOpenInVscode": true,
+        "hideReplaceMyCode": true
     },
     "queryVariants": {
         "skillsMap=1": {
             "appTheme": {
                 "embeddedTutorial": true,
                 "allowParentController": true,
-                "shareFinishedTutorials": false
+                "shareFinishedTutorials": false,
+                "hideReplaceMyCode": false
             }
         },
         "clever=1": {


### PR DESCRIPTION
This addresses the issue mentioned in this comment: https://github.com/microsoft/pxt-microbit/issues/5167#issuecomment-1555362780

Makes use of the existing hideReplaceMyCode flag: https://github.com/microsoft/pxt/blob/master/webapp/src/components/tutorial/TutorialContainer.tsx#L273