### PR TITLE
No 'instructions tab' in skillmaps

### DIFF
--- a/docs/skillmap/forest_new/forest1.md
+++ b/docs/skillmap/forest_new/forest1.md
@@ -60,7 +60,7 @@ tiles.setTilemap(tilemap`level1`)
 
 Open the game window to take a look at the scene you've just set up.
 
-When you're ready to continue, click into the instructions tab again!
+When you're ready to continue, click **Next** to move on to the next step.
 
 
 

--- a/docs/skillmap/shark/shark1-simple.md
+++ b/docs/skillmap/shark/shark1-simple.md
@@ -61,7 +61,7 @@ let mySprite = sprites.create(assets.image`shark`, SpriteKind.Player)
 
 Open the game window to take a look at the scene you've just set up.
 
-When you're ready to continue, click into the instructions tab again!
+When you're ready to continue, click **Next** to move on to the next step.
 
 
 ## 5. Make it Move


### PR DESCRIPTION
Mention moving to the **Next** step instead the using the obsolete "instructions tab".

Closes #5918 