### PR TITLE
try omitting docs from upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
         "built/*.js",
         "built/*.json",
         "built/*.d.ts",
-        "sim/public",
-        "docs/**",
-        "!docs/**/*.gif"
+        "sim/public"
     ],
     "devDependencies": {
         "@types/marked": "^0.3.0",


### PR DESCRIPTION
Should be fine as no one should be consuming docs this way (you would usually clone or fork repo). Worth noting https://github.com/microsoft/pxt-arcade/pull/4515 was removing .gifs before but now that's not working; maybe a weird regression in files field parsing in node 16 since I bumped that recently (https://github.com/microsoft/pxt-arcade/pull/5940/files)?