### PR TITLE
upgrade rule to fix invalid translations in hot fix

### DIFF
--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -251,9 +251,7 @@ namespace pxt.editor {
                 tileHitParam.appendChild(shadow);
                 block.appendChild(tileHitParam);
             });
-        }
 
-        if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "0.18.9") < 0) {
             /**
              * move from tilemap namespace to tiles namespace
              * <block type="tilemap_locationXY">
@@ -269,6 +267,42 @@ namespace pxt.editor {
                 const xyField = getField(block, "xy");
                 xyField.textContent = (xyField.textContent || "").replace(/^tilemap./, "tiles.");
             });
+        }
+
+        if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "1.12.34") < 0) {
+            const lang = pxt.BrowserUtils.getCookieLang();
+            if (lang == "es-MX") {
+
+            } else if (lang === "es-ES") {
+                pxt.U.toArray(dom.querySelectorAll("[type=music_sounds]>field[name=note]"))
+                    .forEach(node => node.setAttribute("name", "name"));
+                // on a button pressed
+                pxt.U.toArray(dom.querySelectorAll("block[type=keyonevent]"))
+                    .forEach(eventRoot => {
+                        const eventField = eventRoot.querySelector("field[name=event]");
+                        const buttonField = eventRoot.querySelector("field[name=button]");
+                        if (!buttonField || !eventField) return;
+                        if (!eventField.innerHTML.startsWith("ControllerButtonEvent.")
+                                && buttonField.innerHTML.startsWith("ControllerButtonEvent.")) {
+                            // swapped by invalid translation we now catch; swap back
+                            eventField.setAttribute("name", "button");
+                            buttonField.setAttribute("name", "event");
+                        }
+                    });
+                // on player 2 a button pressed
+                pxt.U.toArray(dom.querySelectorAll("block[type=ctrlonbuttonevent]"))
+                    .forEach(eventRoot => {
+                        const controllerField = eventRoot.querySelector("field[name=controller]");
+                        const buttonField = eventRoot.querySelector("field[name=button]");
+                        if (!buttonField || !controllerField) return;
+                        if (!buttonField.innerHTML.startsWith("ControllerButton.")
+                                && controllerField.innerHTML.startsWith("ControllerButton.")) {
+                            // swapped by invalid translation we now catch; swap back
+                            controllerField.setAttribute("name", "button");
+                            buttonField.setAttribute("name", "controller");
+                        }
+                    });
+            }
         }
     }
 

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -307,7 +307,7 @@ namespace pxt.editor {
         const fieldB = eventRoot.querySelector(`field[name=${fieldBName}]`);
         if (!fieldB || !fieldA) return;
         if (!fieldA.innerHTML.startsWith(fieldAShouldStartWith)
-                && fieldA.innerHTML.startsWith(fieldAShouldStartWith)) {
+                && fieldB.innerHTML.startsWith(fieldAShouldStartWith)) {
             // swapped by invalid translation we now catch; swap back
             fieldA.setAttribute("name", fieldBName);
             fieldB.setAttribute("name", fieldAName);

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -276,15 +276,7 @@ namespace pxt.editor {
                 // on player 2 a button pressed
                 pxt.U.toArray(dom.querySelectorAll("block[type=ctrlonbuttonevent]"))
                 .forEach(eventRoot => {
-                    const controllerField = eventRoot.querySelector("field[name=controller]");
-                    const buttonField = eventRoot.querySelector("field[name=button]");
-                    if (!buttonField || !controllerField) return;
-                    if (!buttonField.innerHTML.startsWith("ControllerButton.")
-                            && controllerField.innerHTML.startsWith("ControllerButton.")) {
-                        // swapped by invalid translation we now catch; swap back
-                        controllerField.setAttribute("name", "button");
-                        buttonField.setAttribute("name", "controller");
-                    }
+                    swapFieldIfNotMatching(eventRoot, "button", "controller", "ControllerButton.");
                 });
             } else if (lang === "es-ES") {
                 pxt.U.toArray(dom.querySelectorAll("[type=music_sounds]>field[name=note]"))
@@ -292,28 +284,12 @@ namespace pxt.editor {
                 // on a button pressed
                 pxt.U.toArray(dom.querySelectorAll("block[type=keyonevent]"))
                     .forEach(eventRoot => {
-                        const eventField = eventRoot.querySelector("field[name=event]");
-                        const buttonField = eventRoot.querySelector("field[name=button]");
-                        if (!buttonField || !eventField) return;
-                        if (!eventField.innerHTML.startsWith("ControllerButtonEvent.")
-                                && buttonField.innerHTML.startsWith("ControllerButtonEvent.")) {
-                            // swapped by invalid translation we now catch; swap back
-                            eventField.setAttribute("name", "button");
-                            buttonField.setAttribute("name", "event");
-                        }
+                        swapFieldIfNotMatching(eventRoot, "event", "button", "ControllerButtonEvent.");
                     });
                 // on player 2 a button pressed
                 pxt.U.toArray(dom.querySelectorAll("block[type=ctrlonbuttonevent]"))
                     .forEach(eventRoot => {
-                        const controllerField = eventRoot.querySelector("field[name=controller]");
-                        const buttonField = eventRoot.querySelector("field[name=button]");
-                        if (!buttonField || !controllerField) return;
-                        if (!buttonField.innerHTML.startsWith("ControllerButton.")
-                                && controllerField.innerHTML.startsWith("ControllerButton.")) {
-                            // swapped by invalid translation we now catch; swap back
-                            controllerField.setAttribute("name", "button");
-                            buttonField.setAttribute("name", "controller");
-                        }
+                        swapFieldIfNotMatching(eventRoot, "button", "controller", "ControllerButton.");
                     });
             } else if (lang === "de") {
                 pxt.U.toArray(dom.querySelectorAll("block[type=image_create]>value[name=heNacht]"))
@@ -321,6 +297,24 @@ namespace pxt.editor {
             }
         }
     }
+
+    function swapFieldIfNotMatching(
+        eventRoot: Element,
+        fieldAName: string,
+        fieldBName: string,
+        fieldAShouldStartWith: string
+    ) {
+        const fieldA = eventRoot.querySelector(`field[name=${fieldAName}]`);
+        const fieldB = eventRoot.querySelector(`field[name=${fieldBName}]`);
+        if (!fieldB || !fieldA) return;
+        if (!fieldA.innerHTML.startsWith(fieldAShouldStartWith)
+                && fieldA.innerHTML.startsWith(fieldAShouldStartWith)) {
+            // swapped by invalid translation we now catch; swap back
+            fieldA.setAttribute("name", fieldBName);
+            fieldB.setAttribute("name", fieldAName);
+        }
+    }
+
 
     function changeVariableToSpriteReporter(varBlockOrShadow: Element, reporterName: string) {
         const varField = getField(varBlockOrShadow, "VAR");

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -270,7 +270,6 @@ namespace pxt.editor {
         }
 
         if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "1.12.34") < 0) {
-            // ar, zh-CN, zh-TW, fr, ja fine
             const lang = pxt.BrowserUtils.getCookieLang();
             if (lang == "es-MX") {
                 // on player 2 a button pressed

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -270,9 +270,22 @@ namespace pxt.editor {
         }
 
         if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "1.12.34") < 0) {
+            // ar, zh-CN, zh-TW, fr, ja fine
             const lang = pxt.BrowserUtils.getCookieLang();
             if (lang == "es-MX") {
-
+                // on player 2 a button pressed
+                pxt.U.toArray(dom.querySelectorAll("block[type=ctrlonbuttonevent]"))
+                .forEach(eventRoot => {
+                    const controllerField = eventRoot.querySelector("field[name=controller]");
+                    const buttonField = eventRoot.querySelector("field[name=button]");
+                    if (!buttonField || !controllerField) return;
+                    if (!buttonField.innerHTML.startsWith("ControllerButton.")
+                            && controllerField.innerHTML.startsWith("ControllerButton.")) {
+                        // swapped by invalid translation we now catch; swap back
+                        controllerField.setAttribute("name", "button");
+                        buttonField.setAttribute("name", "controller");
+                    }
+                });
             } else if (lang === "es-ES") {
                 pxt.U.toArray(dom.querySelectorAll("[type=music_sounds]>field[name=note]"))
                     .forEach(node => node.setAttribute("name", "name"));
@@ -302,6 +315,9 @@ namespace pxt.editor {
                             buttonField.setAttribute("name", "controller");
                         }
                     });
+            } else if (lang === "de") {
+                pxt.U.toArray(dom.querySelectorAll("block[type=image_create]>value[name=heNacht]"))
+                    .forEach(node => node.setAttribute("name", "height"));
             }
         }
     }


### PR DESCRIPTION
Fix the cases that seemed relevant with https://github.com/microsoft/pxt/pull/9611, so we can port it without breaking too many people and fix things like https://forum.makecode.com/t/error-when-using-makecode-arcade-in-google-chrome/21210/4

This should handle swapping them back, though will want to test in stable just to double check. I found the ones that were problematic here using the logs that I added when we get translations that are rejected, so these are the ones that were valid in live but caught as invalid in beta
![image](https://github.com/microsoft/pxt-arcade/assets/5615930/9790bbc6-043d-4f3e-a6b0-751f91d97442)
