### PR TITLE
Kiosk: fixing time=0 bug

### DIFF
--- a/kiosk/src/Components/AddingGame.tsx
+++ b/kiosk/src/Components/AddingGame.tsx
@@ -32,7 +32,7 @@ const AddingGame: React.FC<IProps> = ({ kiosk }) => {
             return parseInt(kioskCodeTime);
         } else if (kiosk.time) {
             const kioskTime = parseInt(kiosk.time);
-            return (kioskTime > 240 ? 240 : kioskTime) * 60;
+            return (kioskTime > 240 ? 240 : (kioskTime === 0 ? 0.5 :kioskTime)) * 60;
         } else {
             return 30;
         }


### PR DESCRIPTION
For the time flag, I made sure that the user couldn't specify higher than 240, but didn't check the floor. The regex allows the time=0 to pass through, and right now, it makes the UI kinda freak out. It wasn't apparent to me whether or not it was making a lot of requests to the backend at the time, but either way, it's something to be fixed.

We don't want time=0 to be possible, so I've made it so that if time=0 is specified, it will just resort to the default.

One thing to note as this change will still allow time entries like 024 or any number that starts with 0 or 00. It will just take the value of the first non-zero numbers. For example, 024 just resulted in a 24 hour code. Something like 001 will just result in an hour long code. 

I know we can limit this with the regex by making it so leading zeros aren't valid; this will just make the timeout the default 30 minutes. 

I don't have a strong preference for one over the other, but the zero check is  the first solution I thought of.