### PR TITLE
ugly glue for sharable kiosk code

### DIFF
--- a/kiosk/src/App.tsx
+++ b/kiosk/src/App.tsx
@@ -14,8 +14,14 @@ const url = window.location.href;
 const clean = !!/clean(?:[:=])1/.test(url);
 const locked = !!/lock(?:[:=])1/i.test(url);
 const time = (/time=((?:[0-9]{1,3}))/i.exec(url))?.[1];
+const shareSrc = /shared[:=]([^#?]+)/i.exec(url)?.[1];
 
-const kioskSingleton: Kiosk = new Kiosk(clean, locked, time);
+const kioskSingleton: Kiosk = new Kiosk({
+  clean,
+  locked,
+  time,
+  shareSrc,
+});
 kioskSingleton.initialize().catch(error => alert(error));
 
 function App() {

--- a/kiosk/src/Components/MainMenu.tsx
+++ b/kiosk/src/Components/MainMenu.tsx
@@ -7,6 +7,7 @@ import HighScoresList from "./HighScoresList";
 import { DeleteButton } from "./DeleteButton";
 import { tickEvent } from "../browserUtils";
 import DeletionModal from "./DeletionModal";
+import { createKioskShareLink } from "../share";
 
 interface IProps {
     kiosk: Kiosk
@@ -49,7 +50,7 @@ const MainMenu: React.FC<IProps> = ({ kiosk }) => {
                     updateLoop();
                 }
             }, configData.GamepadPollLoopMilli);
-            
+
             return () => {
                 if (intervalId) {
                     clearInterval(intervalId);
@@ -60,6 +61,17 @@ const MainMenu: React.FC<IProps> = ({ kiosk }) => {
         }
     });
 
+    const onUploadClick = async () => {
+        const sharePointer = await createKioskShareLink({
+            games: kiosk.games,
+        });
+
+        const outputLink = `https://arcade.makecode.com/kiosk?shared=${sharePointer}`;
+
+        alert(`send em to ${outputLink}`);
+        console.log(outputLink);
+    }
+
     return(
         <div className="mainMenu">
             <nav className="mainMenuTopBar">
@@ -69,6 +81,9 @@ const MainMenu: React.FC<IProps> = ({ kiosk }) => {
                     <div className="mainMenuButton">
                         <AddGameButton selected={addButtonSelected} content="Add your game" />
                     </div>
+                }
+                {
+                    !kiosk.locked && <button tabIndex={0} onClick={onUploadClick}>click me to upload</button>
                 }
             </nav>
             <GameList kiosk={kiosk} addButtonSelected={addButtonSelected}
@@ -81,5 +96,5 @@ const MainMenu: React.FC<IProps> = ({ kiosk }) => {
         </div>
     )
 }
-  
+
 export default MainMenu;

--- a/kiosk/src/browserUtils.ts
+++ b/kiosk/src/browserUtils.ts
@@ -22,3 +22,4 @@ export function devicePixelRatio(): number {
 export function isLocal() {
     return window.location.hostname === "localhost";
 }
+

--- a/kiosk/src/share.ts
+++ b/kiosk/src/share.ts
@@ -1,0 +1,93 @@
+import { GameData } from "./Models/GameData";
+
+const apiRoot = "https://www.makecode.com";
+const description = "A kiosk for MakeCode Arcade";
+
+export interface SharedKioskData {
+    games: GameData[];
+}
+
+export async function createKioskShareLink(kioskData: SharedKioskData) {
+    const payload = createShareRequest(
+        "kiosk",
+        createProjectFiles("kiosk", kioskData)
+    );
+    const url = apiRoot + "/api/scripts";
+
+    const result = await fetch(
+        url,
+        {
+            method: "POST",
+            body: new Blob([JSON.stringify(payload)], { type: "application/json" })
+        }
+    );
+
+    if (result.status === 200) {
+        const resJSON = await result.json();
+        // return "https://arcade.makecode.com/" + resJSON.shortid;
+        return `${resJSON.shortid}/kiosk.json`;
+    }
+
+    return "ERROR"
+}
+
+
+function createShareRequest(projectName: string, files: {[index: string]: string}) {
+    const header = {
+        "name": projectName,
+        "meta": {
+        },
+        "editor": "tsprj",
+        "pubId": undefined,
+        "pubCurrent": false,
+        "target": "arcade",
+        "id": crypto.randomUUID(),
+        "recentUse": Date.now(),
+        "modificationTime": Date.now(),
+        "path": projectName,
+        "saveId": {},
+        "githubCurrent": false,
+        "pubVersions": []
+    }
+
+    return {
+        id: header.id,
+        name: projectName,
+        target: header.target,
+        description: description,
+        editor: "tsprj",
+        header: JSON.stringify(header),
+        text: JSON.stringify(files),
+        meta: {
+        }
+    }
+}
+
+function createProjectFiles(projectName: string, kioskData: SharedKioskData) {
+    const files: {[index: string]: string} = {};
+
+    const config = {
+        "name": projectName,
+        "description": description,
+        "dependencies": {
+            "device": "*"
+        },
+        "files": [
+            "main.ts",
+            "kiosk.json"
+        ],
+        "preferredEditor": "tsprj"
+    };
+    files["pxt.json"] = JSON.stringify(config, null, 4);
+    files["main.ts"] = " ";
+    files["kiosk.json"] = JSON.stringify(kioskData, undefined, 4);
+
+    return files;
+}
+
+export async function getSharedKioskData(shareId: string, filename: string): Promise<SharedKioskData> {
+    const resp = await fetch(`${apiRoot}/api/${shareId}/text`);
+    const proj: any = await resp.json();
+    const kioskData = JSON.parse(proj[filename]);
+    return kioskData;
+}


### PR DESCRIPTION
adds a button to create a share link with a kiosk in it: 
![image](https://github.com/microsoft/pxt-arcade/assets/5615930/bd2eb4f3-7eb9-4677-b113-ae31fa9ef2af)

which when clicked alerts out a link like https://arcade.makecode.com/kiosk?shared=_8oUCky7VwE91/kiosk.json ( for local testing would point at something like http://localhost:3000/static/kiosk?shared=_CCqJHuFeycUR/kiosk.json ), which when loaded shows up locked like this 
![image](https://github.com/microsoft/pxt-arcade/assets/5615930/e26ccd6f-5fe0-41b8-aed0-2b6f00ccdf80)


This is not code to merge directly (well, could merge and not deploy, while tackling ui / ux layer in a separate pr), I just decided to hack it together as a proof of concept for how easy it is to add in support with 

(copied a good portion of the share.ts from richard font editor, which I believe was copied from asset editor, which was copied from pxtlib :) can dedup later)

we can change the format however we want; if we want to elide the /kiosk.json we could get away with saving it as `kiosk.data` or something and pulling in, just did an easy hack that semi matches github tutorials fetching logic. When this moves over to pxt / kiosk is transitioned to use pxtlib can dedup a bit and e.g. support github projects with kiosk data in them in the same way.