### PR TITLE
Kiosk: Making delete button disappear when locked

### DIFF
--- a/kiosk/src/Components/GameList.tsx
+++ b/kiosk/src/Components/GameList.tsx
@@ -158,7 +158,7 @@ const GameList: React.FC<IProps> = ({ kiosk, addButtonSelected, deleteButtonSele
                     return (
                         <SwiperSlide key={game.id}>
                             <GameSlide highScores={gameHighScores} addButtonSelected={addButtonSelected}
-                                deleteButtonSelected={deleteButtonSelected} game={game} />
+                                deleteButtonSelected={deleteButtonSelected} game={game} locked={kiosk.locked}/>
                         </SwiperSlide>
                     )
                 })}

--- a/kiosk/src/Components/GameSlide.tsx
+++ b/kiosk/src/Components/GameSlide.tsx
@@ -9,12 +9,14 @@ interface IProps {
     addButtonSelected: boolean;
     deleteButtonSelected: boolean;
     game: GameData;
+    locked: boolean;
 }
 const GameSlide: React.FC<IProps> = (
     {   highScores,
         addButtonSelected,
         deleteButtonSelected,
         game,
+        locked
     }) => {
     const buttonSelected = addButtonSelected || deleteButtonSelected;
     const carouselSelected = buttonSelected ? "unselected" : "selected";
@@ -38,6 +40,7 @@ const GameSlide: React.FC<IProps> = (
                     </div>
                 }
                 { game.userAdded &&
+                    !locked &&
                     <DeleteButton focused={deleteButtonSelected} />
                 }
             </div>


### PR DESCRIPTION
When locking the kiosk, the "add game" button would disappear, but the "delete game" button would still be under user-added games. We want the UI to be consistent, so the delete button should go away as well. Because it is locked the user won't be able to navigate down to the button if they try, but this will make the kiosk seem broken since the button is still visible.

Closes https://github.com/microsoft/pxt-arcade/issues/6015