### PR TITLE
Add game jam winners

### DIFF
--- a/docs/game-jam.md
+++ b/docs/game-jam.md
@@ -1,130 +1,137 @@
-# Game Jam: Traffic
-Check out the winners of the 4th Official Microsoft MakeCode Game Jam, featuring games about cars, travel, or traffic! More details can be found on the [official game jam page](https://arcade.makecode.com/gamejam).
+# Game Jam: Prehistoric
+Check out the winners of the 8th Official Microsoft MakeCode Game Jam, featuring prehistoric themed games! More details can be found on the [official game jam page](https://arcade.makecode.com/gamejam/prehistoric).
 
 ## Games
 
 ### ~ codecard
-* name: Glitch
-* description: Polished and imaginative, Glitch is a game where you can slow down time and modify the terrain of the world itself to survive each level.
-* author: Web_Headed_Games
-* url: https://arcade.makecode.com/39412-25824-36790-82290
+* name: DinoZoo
+* description: Simulate the circle of life in this dino-themed falling block game! Created by sylvancircle
+* author: sylvancircle
+* url: https://arcade.makecode.com/22414-21049-08990-36399
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/39412-25824-36790-82290/thumb
+* imageUrl: https://pxt.azureedge.net/api/22414-21049-08990-36399/thumb
 ---
-* name: Last 30 seconds of the universe
-* description: It's (almost) the end of the world, and you are the galaxy's only hope... but are you really alone? This space shooter game may seem impossible at first, but keep playing and you might be surprised.
-* author: felixtsu
-* url: https://arcade.makecode.com/84204-53947-81636-40195
-* cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/84204-53947-81636-40195/thumb
----
-* name: True Love Time Machine
-* description: You were the first tester for a brand new time machine--what could go wrong? Well... maybe one thing. Try and escape the early 2000s and see if you can get all the different possible endings!
-* author: Dylan James C The 1st
-* url: https://arcade.makecode.com/18329-44039-92547-78466
-* cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/18329-44039-92547-78466/thumb
----
-* name: Flying Through Time
-* description: Fast and fun, with an incredible soundtrack--use the experimental time wings to swap between past, present, and future as you zip through different landscapes to rescue your friends.
-* author: lucasmayhew
-* url: https://arcade.makecode.com/29445-50662-54495-27773
-* cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/29445-50662-54495-27773/thumb
----
-* name: Tomb raider
-* description: Adventure through an ancient tomb in this tough-as-nails platformer. See if you can find all 13 ancient gems and the 3 exits before collapse!
-* author: Thomas_s
-* url: https://arcade.makecode.com/12051-52643-75656-27166
-* cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/12051-52643-75656-27166/thumb
----
-* name: The Wanderer
-* description: Explore space and gather materials in this polished, resource-collection game as you try to fix your hyperdrive and escape the supernova!
-* author: DahbixLP
-* url: https://arcade.makecode.com/65329-73524-64041-09452
-* cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/65329-73524-64041-09452/thumb
----
-* name: Timed Platformer
-* description: Make sure you don't run out of time as you play through all twelve levels of this creative platformer!
-* author: fd268
-* url: https://arcade.makecode.com/18905-47762-39268-22513
-* cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/18905-47762-39268-22513/thumb
----
-* name: The Attack of the Serpents
-* description: Dive into the rich world of The Attack of the Serpents as you battle legions of snakes with the power of time at your hand!
+* name: Fossil Clicker
+* description: Collect, sell, upgrade, and repeat in this paleontology simulating idle game! Created by UnsignedArduino
 * author: UnsignedArduino
-* url: https://arcade.makecode.com/88379-32882-11701-72372
+* url: https://arcade.makecode.com/39392-36875-05086-87292
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/88379-32882-11701-72372/thumb
+* imageUrl: https://pxt.azureedge.net/api/39392-36875-05086-87292/thumb
 ---
-* name: Tau Dilation
-* description: The Titan of Time, Kronos, has escaped from Tartarus and it is up to you to defeat him on his own terms.
-* author: Delta
-* url: https://arcade.makecode.com/40197-18454-82229-31469
+* name: Dino Blast
+* description: Search for the legendary dino crystal and save the dinosaurs from evil dragons in this adventure game! Created by InvalidProject99
+* author: InvalidProject99
+* url: https://arcade.makecode.com/48432-56072-58827-08148
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/40197-18454-82229-31469/thumb
+* imageUrl: https://pxt.azureedge.net/api/48432-56072-58827-08148/thumb
 ---
-* name: Time Man
-* description: A complex, ambitious puzzle-platformer where you can freeze time to stop flying boulders. Be careful of quicksand and slime!
-* author: Rishi
-* url: https://arcade.makecode.com/35092-38497-85434-62286
+* name: Booga Bruh
+* description: Find the parts to your broken time machine and make it back to the present in this story-driven RPG! Created by PixelDoodle
+* author: PixelDoodle
+* url: https://arcade.makecode.com/98099-33981-73376-80879
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/35092-38497-85434-62286/thumb
+* imageUrl: https://pxt.azureedge.net/api/98099-33981-73376-80879/thumb
 ---
-* name: Time Quest
-* description: Travel through time to take photos, collect items, and meet friendly and not-so-friendly locals in this beautiful dungeon crawler.
-* author: Rocket Scion
-* url: https://arcade.makecode.com/24218-66945-78169-98108
+* name: Evolve-Adapt-Die (EVO)
+* description: Simulate the evolution process in this creative platforming game where you adapt new abilities each time you die! Created by bluebird77
+* author: bluebird77
+* url: https://arcade.makecode.com/44271-86370-62949-93789
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/24218-66945-78169-98108/thumb
+* imageUrl: https://pxt.azureedge.net/api/44271-86370-62949-93789/thumb
 ---
-* name: Time Flies (Different Take)
-* description: A creative twist on 'Time Flies' with a lot of depth! Catch time and lives as you try to beat your high score.
-* author: BlockyChamp
-* url: https://arcade.makecode.com/56203-12068-28996-67940
+* name: Sent Back in Time!
+* description: Build contraptions to explore a prehistoric world! Created by Kiwiphoenix364
+* author: Kiwiphoenix364
+* url: https://arcade.makecode.com/58507-47430-89537-52451
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/56203-12068-28996-67940/thumb
+* imageUrl: https://pxt.azureedge.net/api/58507-47430-89537-52451/thumb
 ---
-* name: Timing and Patience
-* description: A simple, addicitive game where you must use timing and patience to try and nab the high score. Try out the different difficulty levels!
-* author: EgeoTube Gamez
-* url: https://arcade.makecode.com/28170-65925-97085-38467
+* name: 3D dinosaur model
+* description: A 3D model of a dinosaur running on MakeCode Arcade!?!? Created by Brohann
+* author: Brohann
+* url: https://arcade.makecode.com/19480-91016-21416-55797
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/28170-65925-97085-38467/thumb
+* imageUrl: https://pxt.azureedge.net/api/19480-91016-21416-55797/thumb
 ---
-* name: Time Over
-* description: A beautiful game with a great premise! Collect all the numbers for your clock before time runs out!
-* author: Daniela
-* url: https://arcade.makecode.com/09641-64692-55182-88904
+* name: ROCK GOES!
+* description: Play as a mother dinosaur protecting her eggs from attackers in this beautiful arcade game! Created by windfix y Jacobo
+* author: windfix y Jacobo
+* url: https://arcade.makecode.com/76989-79264-26131-91149
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/09641-64692-55182-88904/thumb
+* imageUrl: https://pxt.azureedge.net/api/76989-79264-26131-91149/thumb
 ---
-* name: fast restaurant
-* description: Deliver the right dishes to the customer as soon as possible in this creative, challenging game.
-* author: demoCrash
-* url: https://arcade.makecode.com/61260-89058-32987-83888
+* name: Excavation Excursion
+* description: Find fossils, make money, buy upgrades, and even collect pets in this paleontology game! Created by Blobbey
+* author: Blobbey
+* url: https://arcade.makecode.com/10189-39800-42881-95047
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/61260-89058-32987-83888/thumb
+* imageUrl: https://pxt.azureedge.net/api/10189-39800-42881-95047/thumb
 ---
-* name: 4-in-1 time-related 8-bit fun
-* description: Four fun, unique games for the price of one! Make sure you play through each of these time-related minigames.
-* author: Samuel G
-* url: https://arcade.makecode.com/19854-09262-25388-69397
+* name: Dino Escape
+* description: Play as a dinosaur attempting to escape the aftermath of the meteor extinction event! Created by Octodemon6611
+* author: Octodemon6611
+* url: https://arcade.makecode.com/19150-26279-62459-54463
 * cardType: sharedExample
-* imageUrl: https://pxt.azureedge.net/api/19854-09262-25388-69397/thumb
+* imageUrl: https://pxt.azureedge.net/api/19150-26279-62459-54463/thumb
+---
+* name: Dinosaur Trials
+* description: Play as an ancient race of dinosaurs trying to escape from a monotone world in this take on a classic reaction game! Created by ChimbroDaPro
+* author: ChimbroDaPro
+* url: https://arcade.makecode.com/08454-95391-77195-94199
+* cardType: sharedExample
+* imageUrl: https://pxt.azureedge.net/api/08454-95391-77195-94199/thumb
+---
+* name: DinoCraft
+* description: Break blocks and build structures in this MineCraft inspired platformer! Created by jnegative
+* author: jnegative
+* url: https://arcade.makecode.com/64311-47617-88529-78446
+* cardType: sharedExample
+* imageUrl: https://pxt.azureedge.net/api/64311-47617-88529-78446/thumb
+---
+* name: Prehistoric Dan
+* description: Head back in time to scan dinosaurs and help your boss not get fired! Created by Maketendo
+* author: Maketendo
+* url: https://arcade.makecode.com/70057-29128-20368-99273
+* cardType: sharedExample
+* imageUrl: https://pxt.azureedge.net/api/70057-29128-20368-99273/thumb
+---
+* name: S&A - Prechistoric World
+* description: Find the missing battery for your time machine in this sidescrolling adventure game! Created by Lisiu23
+* author: Lisiu23
+* url: https://arcade.makecode.com/57672-87358-35699-32284
+* cardType: sharedExample
+* imageUrl: https://pxt.azureedge.net/api/57672-87358-35699-32284/thumb
+---
+* name: Dinosaur Hunting
+* description: Fight dinosaurs and ghosts in this classic SHMUP game! Created by Sayem
+* author: Sayem
+* url: https://arcade.makecode.com/22703-75962-83076-91368
+* cardType: sharedExample
+* imageUrl: https://pxt.azureedge.net/api/22703-75962-83076-91368/thumb
+---
+* name: Dino's Great adventure
+* description: Play as a mother dino finding a place to lay her egg just after the meteor struck the earth 65 million year ago in this platformer game! Created by Bifrost22
+* author: Bifrost22
+* url: https://arcade.makecode.com/69680-60757-30003-05179
+* cardType: sharedExample
+* imageUrl: https://pxt.azureedge.net/api/69680-60757-30003-05179/thumb
+---
+* name: Prehistoric Explorer
+* description: Travel back in time and dodge dinosaurs while trying to get home in this adventure game! Created by catstudio Games
+* author: catstudio Games
+* url: https://arcade.makecode.com/52290-68197-81450-36464
+* cardType: sharedExample
+* imageUrl: https://pxt.azureedge.net/api/52290-68197-81450-36464/thumb
 ---
 * name: See more...
-* description: Check out all the entries on the official game jam page!
+* description: Check out all the entries on the official game jam page! Created by sylvancircle
 * cardType: link
 * directOpen: true
-* imageUrl: /static/gamejam/jams/time/assets/preview.png
-* url: https://arcade.makecode.com/gamejam/time
+* imageUrl: /static/gamejam/jams/prehistoric/assets/preview.png
+* url: https://arcade.makecode.com/gamejam/prehistoric
 
 ### ~
 
 ## See Also
 
-[Game Jam Page](https://arcade.makecode.com/gamejam/time)
+[Game Jam Page](https://arcade.makecode.com/gamejam/prehistoric)

--- a/docs/game-jam.md
+++ b/docs/game-jam.md
@@ -12,7 +12,7 @@ Check out the winners of the 8th Official Microsoft MakeCode Game Jam, featuring
 * imageUrl: https://pxt.azureedge.net/api/22414-21049-08990-36399/thumb
 ---
 * name: Fossil Clicker
-* description: Collect, sell, upgrade, and repeat in this paleontology simulating idle game! Created by UnsignedArduino
+* description: Collect, sell, upgrade, and repeat in this idle game simulating paleontology! Created by UnsignedArduino
 * author: UnsignedArduino
 * url: https://arcade.makecode.com/39392-36875-05086-87292
 * cardType: sharedExample

--- a/docs/gamejam/prehistoric.html
+++ b/docs/gamejam/prehistoric.html
@@ -24,17 +24,6 @@
         </div>
         <div class="checker"></div>
         <div class="content">
-            <h1>It's game jam time!</h1>
-            <div class="segment">
-                <p>
-                    Welcome to the 8th Official Microsoft MakeCode Game Jam! This is a fun
-                    competition where you can pit your game development skills against
-                    others to build a game using <a href="https://arcade.makecode.com">MakeCode Arcade</a>,
-                    a game engine for retro pixel-art games that run in the browser
-                    or on handheld game devices.
-                </p>
-                <div id="timer"></div>
-            </div>
             <div class="segment">
                 <div id="rules"></div>
             </div>

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -53,7 +53,7 @@
     {
         "name": "Game Jam",
         "url": "/game-jam",
-        "imageUrl": "https://pxt.azureedge.net/api/39412-25824-36790-82290/thumb"
+        "imageUrl": "https://pxt.azureedge.net/api/22414-21049-08990-36399/thumb"
     },
     {
         "name": "Advanced Livestream",

--- a/docs/static/gamejam/jams/prehistoric/info.json
+++ b/docs/static/gamejam/jams/prehistoric/info.json
@@ -4,6 +4,84 @@
     },
     "featured": [
         {
+            "id": "_Rf7Ka6f5tMPh",
+            "title": "Sent Back in Time!",
+            "author": "Kiwiphoenix364",
+            "description": "Build contraptions to explore a prehistoric world!"
+        },
+        {
+            "id": "S53740-96945-19140-48669",
+            "title": "Prehistoric Explorer",
+            "author": "catstudio Games",
+            "description": "Travel back in time and dodge dinosaurs while trying to get home in this adventure game!"
+        },
+        {
+            "id": "S75139-85271-35208-66455",
+            "title": "Dinosaur Hunting",
+            "author": "Sayem",
+            "description": "Fight dinosaurs and ghosts in this classic SHMUP game!"
+        },
+        {
+            "id": "S63195-99979-78338-71563",
+            "title": "Prehistoric Dan",
+            "author": "Maketendo",
+            "description": "Head back in time to scan dinosaurs and help your boss not get fired!"
+        },
+        {
+            "id": "S01748-68721-30836-46553",
+            "title": "Dino Escape",
+            "author": "Octodemon6611",
+            "description": "Play as a dinosaur attempting to escape the aftermath of the meteor extinction event!"
+        },
+        {
+            "id": "S06834-22429-91300-47706",
+            "title": "S&A - Prechistoric World",
+            "author": "Lisiu23",
+            "description": "Find the missing battery for your time machine in this sidescrolling adventure game!"
+        },
+        {
+            "id": "S77904-05588-07721-68006",
+            "title": "DinoCraft",
+            "author": "jnegative",
+            "description": "Break blocks and build structures in this MineCraft inspired platformer!"
+        },
+        {
+            "id": "_36chFUaaYgrY",
+            "title": "Dinosaur Trials",
+            "author": "ChimbroDaPro",
+            "description": "Play as an ancient race of dinosaurs trying to escape from a monotone world in this take on a classic reaction game!"
+        },
+        {
+            "id": "S00177-35633-77859-17379",
+            "title": "Excavation Excursion",
+            "author": "Blobbey",
+            "description": "Find fossils, make money, buy upgrades, and even collect pets in this paleontology game!"
+        },
+        {
+            "id": "S83557-52602-39655-60991",
+            "title": "ROCK GOES!",
+            "author": "windfix y Jacobo",
+            "description": "Play as a mother dinosaur protecting her eggs from attackers in this beautiful arcade game!"
+        },
+        {
+            "id": "S93197-18791-04197-56384",
+            "title": "3D dinosaur model",
+            "author": "Brohann",
+            "description": "A 3D model of a dinosaur running on MakeCode Arcade!?!?"
+        },
+        {
+            "id": "_JMMdwyUFbghf",
+            "title": "Evolve-Adapt-Die (EVO)",
+            "author": "bluebird77",
+            "description": "Simulate the evolution process in this creative platforming game where you adapt new abilities each time you die!"
+        },
+        {
+            "id": "S61823-59071-17256-01643",
+            "title": "Dino's Great adventure",
+            "author": "Bifrost22",
+            "description": "Play as a mother dino finding a place to lay her egg just after the meteor struck the earth 65 million year ago in this platformer game!"
+        },
+        {
             "id": "S00497-98855-08431-02510",
             "title": "Dinosaur Race",
             "author": "CDG studios"
@@ -117,11 +195,6 @@
             "id": "_T0iYgMXRD838",
             "title": "Dino Crash",
             "author": "Da Footy Gamer"
-        },
-        {
-            "id": "_36chFUaaYgrY",
-            "title": "Dinosaur Trials",
-            "author": "ChimbroDaPro"
         },
         {
             "id": "S50359-03714-75042-35584",
@@ -244,11 +317,6 @@
             "author": "Shadow_Tiger"
         },
         {
-            "id": "S53740-96945-19140-48669",
-            "title": "Prehistoric Explorer",
-            "author": "catstudio Games"
-        },
-        {
             "id": "_bkyPzJ0X7Amv",
             "title": "解救小恐龙",
             "author": "Arir"
@@ -279,11 +347,6 @@
             "author": "Snuggly Jewelsies"
         },
         {
-            "id": "S93197-18791-04197-56384",
-            "title": "3D dinosaur model",
-            "author": "Brohann"
-        },
-        {
             "id": "S58499-28409-67513-26487",
             "title": "Dino Button",
             "author": "Mushfiq"
@@ -297,11 +360,6 @@
             "id": "S74242-80212-01982-22938",
             "title": "Animate it!",
             "author": "Andy"
-        },
-        {
-            "id": "S75139-85271-35208-66455",
-            "title": "Dinosaur Hunting",
-            "author": "Sayem"
         },
         {
             "id": "_gRvTvTe7yevk",
@@ -319,11 +377,6 @@
             "author": "Isaac"
         },
         {
-            "id": "S63195-99979-78338-71563",
-            "title": "Prehistoric Dan",
-            "author": "Maketendo"
-        },
-        {
             "id": "S13029-49096-56602-54759",
             "title": "Dino Run",
             "author": "Kat"
@@ -334,11 +387,6 @@
             "author": "Jupiter"
         },
         {
-            "id": "S77904-05588-07721-68006",
-            "title": "DinoCraft",
-            "author": "jnegative"
-        },
-        {
             "id": "_V64Kc709mT7f",
             "title": "Prehistoric Fishing",
             "author": "Ethan C., Michael T., and Mr. Hartung"
@@ -347,11 +395,6 @@
             "id": "S34588-99263-71409-55447",
             "title": "Fossil Collector",
             "author": "H D-D"
-        },
-        {
-            "id": "S00177-35633-77859-17379",
-            "title": "Excavation Excursion",
-            "author": "Blobbey"
         },
         {
             "id": "S87080-42073-72400-88003",
@@ -414,24 +457,9 @@
             "author": "Oscar_Cubes"
         },
         {
-            "id": "S01748-68721-30836-46553",
-            "title": "Dino Escape",
-            "author": "Octodemon6611"
-        },
-        {
-            "id": "S83557-52602-39655-60991",
-            "title": "ROCK GOES!",
-            "author": "windfix y Jacobo"
-        },
-        {
             "id": "_9wPeUXRAPesT",
             "title": "A pale day",
             "author": "Carpet 36"
-        },
-        {
-            "id": "S61823-59071-17256-01643",
-            "title": "Dino's Great adventure",
-            "author": "Bifrost22"
         },
         {
             "id": "S47513-06009-32854-09562",
@@ -454,24 +482,9 @@
             "author": "GuhhanSP"
         },
         {
-            "id": "S06834-22429-91300-47706",
-            "title": "S&A - Prechistoric World",
-            "author": "Lisiu23"
-        },
-        {
             "id": "S24155-16075-13221-53173",
             "title": "Dino platformer",
             "author": "Rh0eR0"
-        },
-        {
-            "id": "_Rf7Ka6f5tMPh",
-            "title": "Sent Back in Time!",
-            "author": "Kiwiphoenix364"
-        },
-        {
-            "id": "_JMMdwyUFbghf",
-            "title": "Evolve-Adapt-Die (EVO)",
-            "author": "bluebird77"
         },
         {
             "id": "S16353-47569-22918-24916",

--- a/docs/static/gamejam/jams/prehistoric/rules.md
+++ b/docs/static/gamejam/jams/prehistoric/rules.md
@@ -1,48 +1,33 @@
-## Prehistoric Jam
+## Prehistoric Jam Winners!
 
-The theme for this jam is "prehistoric". In other words, we're looking for games starring dinosaurs, sabertooth tigers, or really just about anything from a long, long, time ago.
-Some examples of good interpretations of this theme are:
+We're thrilled to announce the winners of the eighth MakeCode Arcade game jam: Prehistoric Jam! This was one of our most successful game jams to date with a whopping **106** entries. We hope you'll enjoy playing some of our favorites:
 
-1. A paleontology game where you unearth and clean fossils for a museum
-2. A survival game where a time-travel experiment strands you in the past
-3. A fighting game where you play as a dinosaur boxing with an anthropomorphized meteor
 
-DEMO GIF 1 | DEMO GIF 2 | DEMO GIF 3
--- | --
-![](/static/gamejam/jams/prehistoric/assets/demo-1.gif) | ![](/static/gamejam/jams/prehistoric/assets/demo-2.gif) | ![](/static/gamejam/jams/prehistoric/assets/demo-1.gif)
+## First Place: Dino Zoo
+| [![Dino Zoo screenshot](https://pxt.azureedge.net/api/22414-21049-08990-36399/thumb)](https://arcade.makecode.com/39697-95718-82872-45842) |
+| -- |
+| &nbsp; |
 
-You can interpret "prehistoric" however you want, but someone playing your game should be able to see how it relates to the theme without extra explanation.
+[Dino Zoo](https://arcade.makecode.com/22414-21049-08990-36399) by **SylvanCircle** is an amazing block-based puzzle game where you simulate the circle of life to clear the board of dinosaurs and plants. From the multiple game modes to the detailed tutorial, this game is super polished and fun to play!
 
-## Hurry before this jam is *history*
-The game jam will run from **July 3, 2023** to **July 31, 2023**
+## Second Place: Fossil Clicker
+| [![Fossil Clicker screenshot](https://pxt.azureedge.net/api/39392-36875-05086-87292/thumb)](https://arcade.makecode.com/39392-36875-05086-87292) |
+| -- |
+| &nbsp; |
 
-You will have roughly one month to build and submit your games for the competition! For you procrastinators out there, we will accept games up until 11:59pm on July 31st.
+[Fossil Clicker](https://arcade.makecode.com/39392-36875-05086-87292) by **UnsignedArduino** is an addictive paleontology themed idle game. Collect, sell, upgrade, and repeat until you have more money than there are atoms in the universe! Y'know, just like real paleontologists do!
 
-## Getting started
+## Third Place (tie): Dino Blast
+| [![Dino Blast screenshot](https://pxt.azureedge.net/api/48432-56072-58827-08148/thumb)](https://arcade.makecode.com/48432-56072-58827-08148) |
+| -- |
+| &nbsp; |
 
-Never programmed in Microsoft MakeCode Arcade before? No problem! Check out our [beginner skillmaps](https://arcade.makecode.com/--skillmap#dino) to learn the basics of making a game!
+[Dino Blast](https://arcade.makecode.com/48432-56072-58827-08148) by **InvalidProject99** is an adventure game where you play as a dinosaur exploring the world on a quest to defeat the evil dragon king. With it's innovative use of the player 2 controls, attacking dragons is indeed a blast!
 
-## Rules
+## Third Place (tie): Booga Bruh
+| [![Boogah Bruh screenshot](https://pxt.azureedge.net/api/98099-33981-73376-80879/thumb)](https://arcade.makecode.com/98099-33981-73376-80879) |
+| -- |
+| &nbsp; |
+**NOTE: This game contains rapidly flashing colors and patterns**
 
-1. Games should be built in MakeCode Arcade
-2. Your game must relate to the jam theme. Someone playing your game should be able to see how it relates to the theme without extra explanation.
-3. Keep the games PG: no NSFW, offensive, or excessively violent content.
-4. You must be at least 9 years old to participate.
-5. All games must be submitted by someone who is at least 13 years old. Younger students are welcome to participate, but it must be in partnership with an adult and with parent permission.
-
-## Join the community
-
-This game jam is designed to be an easy introduction to making games, even for folks without prior programming experience! We highly encourage parents and educators to work with interested students to bring their games to life.
-
-Join our [forums](https://forum.makecode.com) to chat with other coders, brainstorm ideas, or form a game jam team. You can hang out with the MakeCode team there too!
-
-## Tips and tricks
-
-* When designing your game, keep in mind that Arcade is restricted to a 160x120 16-color screen
-* See [these instructions](https://arcade.makecode.com/developer/images) for information on importing images and color palettes into Arcade.
-* Check out the [developer documentation](https://arcade.makecode.com/developer) for more advanced tips to use in Arcade.
-* Also make sure you check out the winners of [our][traffic-jam] [past][garden-jam] [jams][ocean-jam]!
-
-[traffic-jam]: https://arcade.makecode.com/gamejam/traffic
-[ocean-jam]: https://arcade.makecode.com/gamejam/ocean
-[garden-jam]: https://arcade.makecode.com/gamejam/garden
+[Booga Bruh](https://arcade.makecode.com/98099-33981-73376-80879) by **PixelDoodle** is a turn based RPG with one of the most engrossing stories we've seen in MakeCode Arcade! Find the parts to your broken time machine and make it back to the present in this story-driven game!

--- a/docs/static/gamejam/lib/gamejam.css
+++ b/docs/static/gamejam/lib/gamejam.css
@@ -212,10 +212,14 @@ h1 {
     flex-direction: column;
 }
 
-#gallery > div,
-#highlighted > div {
+#gallery > div {
     display: flex;
     justify-content: space-around;
+}
+
+#highlighted > div {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
 }
 
 #gallery .game,
@@ -223,6 +227,23 @@ h1 {
     text-align: center;
     margin: 1rem;
     flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#highlighted .game a:first-child {
+    flex-grow: 1;
+}
+
+#highlighted .game .placeholder {
+    width: 100%;
+    height: 100%;
+}
+
+.placeholder img {
+    width: 100px;
+    height: 100px;
+    object-fit: contain;
 }
 
 #gallery .game {

--- a/docs/static/gamejam/lib/gamejam.js
+++ b/docs/static/gamejam/lib/gamejam.js
@@ -163,6 +163,7 @@ function makeWinners() {
     content.insertBefore(parent, gallery);
 }
 function makeGallery() {
+    var _a;
     var container = document.querySelector(".gallery");
     var parent = document.getElementById("gallery");
     if (container && parent) {
@@ -178,7 +179,7 @@ function makeGallery() {
                 on the workspace background.";
             container.insertBefore(hint, parent);
         }
-        var selected = randomize(info.featured); // show all the games
+        var selected = randomize((_a = info.featured) === null || _a === void 0 ? void 0 : _a.filter(function (g) { return !g.description; })); // show all the games
         var row = document.createElement("div");
         for (var i = 0; i < selected.length; i++) {
             row.appendChild(makeGameCard(selected[i]));

--- a/docs/static/gamejam/lib/gamejam.ts
+++ b/docs/static/gamejam/lib/gamejam.ts
@@ -204,7 +204,7 @@ function makeGallery() {
             container.insertBefore(hint, parent);
         }
 
-        let selected = randomize(info.featured); // show all the games
+        let selected = randomize(info.featured?.filter(g => !g.description)); // show all the games
         let row = document.createElement("div");
         for (let i = 0; i < selected.length; i++) {
             row.appendChild(makeGameCard(selected[i]));


### PR DESCRIPTION
This PR does the following:

1. Adds the game jam winners to the prehistoric jam page
2. Fixes a few CSS oddities for the winners section of said page
3. Replaces the time jam carousel on the home page with the entries from this jam