### PR TITLE
Workaround for legacy added games to have the ability to be deleted

### DIFF
--- a/kiosk/src/Models/Kiosk.ts
+++ b/kiosk/src/Models/Kiosk.ts
@@ -137,6 +137,9 @@ export class Kiosk {
         const addedGames = this.getAllAddedGames();
         const addedGamesObjs: GameData[] = Object.values(addedGames);
         for (const game of addedGamesObjs) {
+            if (!game?.userAdded) {
+                game.userAdded = true;
+            }
             if (!game?.deleted) {
                 this.games.push(game);
             }


### PR DESCRIPTION
When we first added the ability to delete user added games, we added a flag to the game entry so it would be easy to check if a game was user-added and thus add the "delete game" button under the game (seen here: https://github.com/microsoft/pxt-arcade/blob/53785bbc401c9fdbe2efb6db77819b8a3398b475/kiosk/src/Components/GameSlide.tsx#L40). That means if you uploaded games before this change, you wouldn't be able to delete them from the game list. In clean mode, when you have a kiosk with newer added games and older added games this logic makes it look like something is broken. 

Because we've added the `userAdded=true` to every game that is added to kiosk now, this will only be a problem for kiosks that have older game uploads, but it's something that we should support. The fact that this "unable to delete" bug will only happen to older games is important, though, because on first load, kiosk fetches and parses through all of the user added games and pushes them to kiosk's game list. The kiosk game list is what we use to display all of the games together. Because we go through all of the added games, we can check to make sure that the local representation of those games have the `userAdded=true` flag. 

An alternative solution would be to, also on first load, go through all of the user added entries, update the `userAdded` flag and then update the localstorage object. However, I think this step adds more work than needed.

Closes https://github.com/microsoft/pxt-arcade/issues/6016