### PR TITLE
[stable1.12] bump to 8.5.52

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.3.23",
-        "pxt-core": "8.5.51"
+        "pxt-core": "8.5.52"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.8"


### PR DESCRIPTION
no code change, just trying a rebuild; guess from richard and I is roughly that the 'once in a blue moon vs/editor/editor.main.css file change' happened during CI and caused something to break, see 1.12.39 in built repo. The result is that the cached codicon.ttf is returning the css file for some reason. Seeing if this rebuild works for now and we can see if we can backtrack to the 'why'