### PR TITLE
enable n4 hardware

### DIFF
--- a/libs/hw---n4/pxt.json
+++ b/libs/hw---n4/pxt.json
@@ -35,7 +35,6 @@
             "DEVICE_WEBUSB": 0
         }
     },
-    "experimentalHw": true,
     "dalDTS": {
         "corePackage": "../core---nrf52"
     }

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -126,6 +126,7 @@
         "base": [
             "libs/hw",
             "libs/hw---n3",
+            "libs/hw---n4",
             "libs/hw---samd51",
             "libs/hw---stm32f401",
             "libs/hw---rp2040"


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/issues/6070