### PR TITLE
set n4 back to experimental, enable n3

### DIFF
--- a/libs/hw---n3/pxt.json
+++ b/libs/hw---n3/pxt.json
@@ -21,7 +21,7 @@
         "core---nrf52": "file:../core---nrf52",
         "screen---st7735": "file:../screen---st7735",
         "mixer---nrf52": "file:../mixer---nrf52",
-        "game": "file:../game"    
+        "game": "file:../game"
     },
     "public": true,
     "skipLocalization": true,
@@ -35,7 +35,6 @@
             "DEVICE_WEBUSB": 0
         }
     },
-    "experimentalHw": true,
     "dalDTS": {
         "corePackage": "../core---nrf52"
     }

--- a/libs/hw---n4/pxt.json
+++ b/libs/hw---n4/pxt.json
@@ -26,6 +26,7 @@
     "public": true,
     "skipLocalization": true,
     "additionalFilePath": "../hw",
+    "experimentalHw": true,
     "yotta": {
         "optionalConfig": {
             "DEVICE_JACDAC_DEBUG": 1


### PR DESCRIPTION
As quick follow up for https://github.com/microsoft/pxt-arcade/pull/6117, to swap the default hardware entry that shows up