### PR TITLE
[stable1.12] Cherry pick n3/n4 fixes

### DIFF
--- a/libs/hw---n3/pxt.json
+++ b/libs/hw---n3/pxt.json
@@ -21,7 +21,7 @@
         "core---nrf52": "file:../core---nrf52",
         "screen---st7735": "file:../screen---st7735",
         "mixer---nrf52": "file:../mixer---nrf52",
-        "game": "file:../game"    
+        "game": "file:../game"
     },
     "public": true,
     "skipLocalization": true,
@@ -35,7 +35,6 @@
             "DEVICE_WEBUSB": 0
         }
     },
-    "experimentalHw": true,
     "dalDTS": {
         "corePackage": "../core---nrf52"
     }

--- a/libs/hw---n4/pxt.json
+++ b/libs/hw---n4/pxt.json
@@ -26,6 +26,7 @@
     "public": true,
     "skipLocalization": true,
     "additionalFilePath": "../hw",
+    "experimentalHw": true,
     "yotta": {
         "optionalConfig": {
             "DEVICE_JACDAC_DEBUG": 1

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -322,21 +322,21 @@
             "description": "Use the micro:bit with an expansion board from Kittenbot",
             "imageUrl": "/static/hardware/newbit.png",
             "url": "https://www.kittenbot.cc/products/newbit-arcade-shield",
-            "variant": "hw---n4"
+            "variant": "hw---n3"
         },
         {
             "name": "micro:bit Retro Shield",
             "description": "Use the micro:bit with an expansion board from Elecfreaks",
             "imageUrl": "/static/hardware/retro-shield.jpg",
             "url": "https://shop.elecfreaks.com/products/micro-bit-retro-programming-arcade",
-            "variant": "hw---n4"
+            "variant": "hw---n3"
         },
         {
             "name": "micro:bit Game:Bit Shield",
             "description": "Use the micro:bit with an expansion board from iCShop",
             "imageUrl": "/static/hardware/bit-shield.png",
             "url": "https://www.icshop.com.tw/products/368112100137",
-            "variant": "hw---n4"
+            "variant": "hw---n3"
         }
     ],
     "galleries": {


### PR DESCRIPTION
porting https://github.com/microsoft/pxt-arcade/pull/6117, https://github.com/microsoft/pxt-arcade/pull/6118

I think they microbit builds will be elided when targetconfig swaps to new one as n3 was still marked disabled until this is merged / bumped