### PR TITLE
MRT maker kit added to compat devices

### DIFF
--- a/docs/arcade-devices.md
+++ b/docs/arcade-devices.md
@@ -21,6 +21,13 @@ These boards run MakeCode Arcade games. Choose a board to find out more about it
         "variant": "hw---stm32f401"
     },
     {
+        "name": "MRT Game Maker Kit",
+        "description": " Sleek hand-held game device with a hard case and a USB-C port.",
+        "imageUrl": "/static/hardware/mrt-gamemaker-kit.png",
+        "url": " https://www.myrobottime.co.kr/gamemakerkit",
+        "variant": "hw---stm32f401"
+    },
+    {
         "name": "Kitronik ARCADE",
         "description": "ARCADE is a programmable gamepad for use with MakeCode Arcade.",
         "imageUrl": "/static/hardware/kitronik.jpg",

--- a/docs/arcade-devices.md
+++ b/docs/arcade-devices.md
@@ -24,7 +24,7 @@ These boards run MakeCode Arcade games. Choose a board to find out more about it
         "name": "MRT Game Maker Kit",
         "description": " Sleek hand-held game device with a hard case and a USB-C port.",
         "imageUrl": "/static/hardware/mrt-gamemaker-kit.png",
-        "url": " https://www.myrobottime.co.kr/gamemakerkit",
+        "url": "https://www.myrobottime.co.kr/gamemakerkit",
         "variant": "hw---stm32f401"
     },
     {

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -31,7 +31,7 @@ These boards run MakeCode Arcade games. They are based on our guidelines, adhere
         "name": "MRT Game Maker Kit",
         "description": " Sleek hand-held game device with a hard case and a USB-C port.",
         "imageUrl": "/static/hardware/mrt-gamemaker-kit.png",
-        "url": " https://www.myrobottime.co.kr/gamemakerkit",
+        "url": "https://www.myrobottime.co.kr/gamemakerkit",
         "variant": "hw---stm32f401"
     },
     {

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -277,7 +277,7 @@
             "name": "MRT Game Maker Kit",
             "description": " Sleek hand-held game device with a hard case and a USB-C port.",
             "imageUrl": "/static/hardware/mrt-gamemaker-kit.png",
-            "url": " https://www.myrobottime.co.kr/gamemakerkit",
+            "url": "https://www.myrobottime.co.kr/gamemakerkit",
             "variant": "hw---stm32f401"
         },
         {


### PR DESCRIPTION
The MRT Maker Kit card was left out of the "Arcade Compatible Devices" gallery in #6198.

Closes #6214.