### PR TITLE
Adding a card to "Download to Drive"

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -261,6 +261,12 @@
     },
     "hardwareOptions": [
         {
+            "name": "Download to Drive",
+            "description": "Download a copy of your game file to your computer",
+            "imageUrl": "/static/hardware/laptop.png",
+            "variant": "hw---stm32f401"
+        },
+        {
             "name": "Meowbit",
             "description": "A retro game console for STEM education from Kittenbot team",
             "imageUrl": "/static/hardware/meowbit.png",


### PR DESCRIPTION
Stashing this here until we're ready to add.  @Jaqster would like more data before we merge.

We have received feedback that people don't know how to save projects other than sharing or uploading to GitHub.  In part, this could be because the save button is touching the name field, so it looks like it's meant to save name changes:
![Screenshot 2023-12-07 at 12 04 19 PM](https://github.com/microsoft/pxt-arcade/assets/1633958/9dd58bb7-8915-4a29-b44d-67b16bd9b3d3)

<br/>

Also, the save button goes away when you're working in a tutorial:
![Screenshot 2023-12-07 at 12 10 42 PM](https://github.com/microsoft/pxt-arcade/assets/1633958/7833be77-489c-4943-8a3a-a357f27529d7)

<br/>

Or a GitHub repo:
![Screenshot 2023-12-07 at 12 09 14 PM](https://github.com/microsoft/pxt-arcade/assets/1633958/6b001a10-7c48-475f-835c-a640f91511cc)


<br/>

The clever educator/student will notice that there's a **Download** button, which seems like the natural place to go when looking to download your project...but when they click, they're faced with these options, none of which are "Download to Drive".
![Screenshot 2023-12-07 at 12 09 32 PM](https://github.com/microsoft/pxt-arcade/assets/1633958/9a86b16f-7f52-4312-a803-fbc7a25960d8)

<br/>

Those of us who work here know that we could choose any of these to save our projects to drive, but there's no way for anyone else to know this is the case. My solution is to add a card for downloading to your machine. 
![Screenshot 2023-12-07 at 12 03 34 PM](https://github.com/microsoft/pxt-arcade/assets/1633958/fb312d02-0cdb-47eb-99df-8321cbf807aa)







