### PR TITLE
exclude type roots from editor build

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.10
+          ref: v0.11.11
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.10
+          ref: v0.11.11
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -7,6 +7,7 @@
         "outFile": "../built/editor.js",
         "rootDir": ".",
         "newLine": "LF",
+        "types": [],
         "sourceMap": false
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "pxt-core": "9.3.8"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.10"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.11"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",


### PR DESCRIPTION
part 2 of the fix for the recent build break.

see part 1 here: https://github.com/microsoft/pxt-arcade-sim/pull/106