### PR TITLE
Add Teacher Tool Eval URL Redirect (and bump pxt-core to 9.3.9) 

### DIFF
--- a/docs/eval-ref.json
+++ b/docs/eval-ref.json
@@ -1,0 +1,3 @@
+{
+    "redirect": "/--eval"
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "11.1.4",
-        "pxt-core": "9.3.8"
+        "pxt-core": "9.3.9"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.11"


### PR DESCRIPTION
This should allow /eval to redirect to /--eval.

Pxt-core bump is needed to get teacher tool content from pxt.