### PR TITLE
Update the repo link for Black Magic Debug

### DIFF
--- a/docs/hardware/dbg.md
+++ b/docs/hardware/dbg.md
@@ -2,7 +2,7 @@
 
 It's often needed to connect a SWD debugger to a board.
 
-We found [Black Magic Probe](https://github.com/blacksphere/blackmagic/wiki) to work well,
+We found [Black Magic Probe](https://github.com/blackmagic-debug/blackmagic) to work well,
 for a variety of MCUs, and it doesn't require openocd.
 You can use their beautifully made hardware, or flash an existing
 board with Black Magic firmware.


### PR DESCRIPTION
This PR addresses some outdatedness in one of the guides you host which has come to the attention of the project which is reference (Black Magic Debug). Please see the updated project repository link in the changes for this PR.

Fair and full disclosure: we are the lead maintainer for the project, however we can certify that the old link was taking people to a wiki that no longer exists and to a GitHub organisation which has nothing to do with the project any more and that the new link points to the current home of the project.

If the link should be to the project's website rather than code repo, we can switch the links over and point it to black-magic.org which is the main website for the project now.