### PR TITLE
Add browser events extension

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.11
+          ref: v0.11.12
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.11
+          ref: v0.11.12
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/libs/browser-events/pxt.json
+++ b/libs/browser-events/pxt.json
@@ -1,0 +1,3 @@
+{
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/browser-events"
+}

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "11.1.4",
+        "pxt-common-packages": "11.1.6",
         "pxt-core": "9.3.10"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.11"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.12"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -120,7 +120,8 @@
         "libs/sprite-scaling",
         "libs/storyboard",
         "libs/template",
-        "libs/thermometer"
+        "libs/thermometer",
+        "libs/browser-events"
     ],
     "staticpkgdirs": {
         "base": [


### PR DESCRIPTION
This PR requires https://github.com/microsoft/pxt-common-packages/pull/1467

The build will fail until that is merged.

Adds the browser events extension to the extension list.