### PR TITLE
Bump pxt-core -> 8.5.59 and common-packges -> 10.3.24

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.10
+          ref: v0.11.11
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.10
+          ref: v0.11.11
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -7,6 +7,7 @@
         "outFile": "../built/editor.js",
         "rootDir": ".",
         "newLine": "LF",
+        "types": [],
         "sourceMap": false
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "10.3.23",
-        "pxt-core": "8.5.57"
+        "pxt-core": "8.5.59"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.11"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pxt-core": "8.5.57"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.10"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.11"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "10.3.23",
+        "pxt-common-packages": "10.3.24",
         "pxt-core": "8.5.59"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Pick up https://github.com/microsoft/pxt/pull/9812 and https://github.com/microsoft/pxt/pull/9792 (and it's corresponding change in common-packages) https://github.com/microsoft/pxt-common-packages/pull/1461

Cherry-pick: exclude type roots from editor build (https://github.com/microsoft/pxt-arcade/pull/6274)