### PR TITLE
Teacher tool: added styling for teachertool=1 url flag

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -685,6 +685,12 @@
                 "shareFinishedTutorials": false,
                 "hideReplaceMyCode": false
             }
+        },
+        "teachertool=1": {
+            "appTheme": {
+                "hideMenuBar": true,
+                "workspaceSearch": true
+            }
         }
     },
     "unsupportedBrowsers": [


### PR DESCRIPTION
We might want to look into a different and more "sticky" pattern for this because if we do the styling this way, we'd have to define this flag in each target. I wasn't sure if there was a way to define url query parameters like this universally without the backend.