### PR TITLE
Add extension to approved list

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -22,7 +22,8 @@
             "microsoft/arcade-character-animations",
             "microsoft/arcade-tile-util",
             "aqeeaqee/pxt-raycasting",
-            "joylabz/makeymakey-makecode-arcade-extension"
+            "joylabz/makeymakey-makecode-arcade-extension",
+            "juliekol/pxt-levels"
         ],
         "preferredRepos": [
             "adafruit/Circuit-Playground-Character-Icons",


### PR DESCRIPTION
Hi,

I created a new extension to add multiple levels support for games.

https://github.com/juliekol/pxt-levels

I followed all the steps in https://makecode.com/extensions/approval and created this PR to add to the list.

Thank you!