### PR TITLE
Changing cabinet homepage card

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -135,10 +135,10 @@ These boards run MakeCode Arcade games. They are based on our guidelines, adhere
         "variant": "hw---rpi"
     },
     {
-        "name": "Arcade cabinet",
-        "description": "Full size Arcade cabinet powered by a Raspberry Pi.",
+        "name": "Arcade cabinets",
+        "description": "Choose one of three options.",
         "imageUrl": "/static/hardware/raspberry-pi/wooden-cabinet/gallery.jpg",
-        "url": "/hardware/raspberry-pi/wooden-cabinet",
+        "url": "/hardware/cabinets",
         "variant": "hw---rpi"
     },
     {


### PR DESCRIPTION
I do need approval on this one since it touches the arcade homepage...

Now that we have three different types of cabinets, we're directing the card on the home page to open a page with all three options. 

![image](https://github.com/microsoft/pxt-arcade/assets/1633958/aedcab95-6235-44c0-b6dd-8a7bb0942260)
