### PR TITLE
Move women's history month higher up in the copy

### DIFF
--- a/docs/gamejam/female-gamechangers.html
+++ b/docs/gamejam/female-gamechangers.html
@@ -44,6 +44,9 @@
         </div>
         <div class="segment">
             <p>
+                <strong>Celebrate Women's History Month with Microsoft MakeCode Arcade!</strong>
+            </p>
+            <p>
                 Welcome to the 9th Official Microsoft MakeCode Game Jam! This is a fun
                 competition where you can pit your game development skills against
                 others to build a game using <a href="https://arcade.makecode.com">MakeCode Arcade</a>,

--- a/docs/static/gamejam/jams/female-gamechangers/rules.md
+++ b/docs/static/gamejam/jams/female-gamechangers/rules.md
@@ -2,7 +2,7 @@
 -- | --
 ![Microsoft logo](/static/gamejam/jams/female-gamechangers/assets/msft-makecode-logo.png) | ![Code ninjas logo](/static/gamejam/jams/female-gamechangers/assets/code-ninjas-logo.svg) | ![Girls Who Code logo](/static/gamejam/jams/female-gamechangers/assets/girls-who-code-logo.png)
 
-For Women's History Month in March, we are excited to partner with Girls Who Code and Code Ninjas to celebrate women who have made an impact in your life through the Female Gamechangers Game Jam!
+This Women's History Month, we are excited to partner with Girls Who Code and Code Ninjas to celebrate women who have made an impact in your life through the Female Gamechangers Game Jam!
 
 The theme for this jam is "Women who impacted your life". Your game could include a famous woman from history, someone you know personally, or even an original character you create!
 


### PR DESCRIPTION
When showing this off today, we got some feedback that Women's history month was sort of buried in the copy. This PR moves it up and makes it bold:

![image](https://github.com/microsoft/pxt-arcade/assets/13754588/6f176295-388f-4478-a021-e1b66ea4c74f)
