### PR TITLE
Temporarily disable upload docs

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -701,7 +701,7 @@
             "id": "ie"
         }
     ],
-    "uploadDocs": true,
+    "uploadDocs": false,
     "noSimShims": true,
     "defaultBadges": [
         {


### PR DESCRIPTION
A temporary measure while we upgrade to the v2 apis