### PR TITLE
Accessibility compliance: editor colors update

### DIFF
--- a/docs/beginner-maps.md
+++ b/docs/beginner-maps.md
@@ -14,7 +14,7 @@
   "imageUrl":  "/static/skillmap/backgrounds/story-map.png",
   "url": "https://arcade.makecode.com/--skillmap#story",
   "label": "New? Try This!",
-  "labelClass": "orange ribbon large",
+  "labelClass": "purple ribbon large",
   "directOpen": true
 },
 {

--- a/docs/skillmaps.md
+++ b/docs/skillmaps.md
@@ -12,7 +12,7 @@
   "imageUrl":  "/static/skillmap/backgrounds/beginner.png",
   "url": "https://arcade.makecode.com/--skillmap#beginner",
   "label": "New? Try This!",
-  "labelClass": "orange ribbon large",
+  "labelClass": "purple ribbon large",
   "directOpen": true
 },
 {

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -14,7 +14,7 @@
   "imageUrl": "/static/tutorials/interface/info.png",
   "largeImageUrl": "/static/tutorials/interface/info.png",
   "label": "New? Try This!",
-  "labelClass": "orange ribbon large"
+  "labelClass": "purple ribbon large"
 },{
   "name": "Chase the Pizza",
   "description": "Get started creating a simple game to chase a pizza around the screen and collect as many points as possible before time runs out!",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -605,10 +605,10 @@
         },
         "blocklyOptions": {
             "grid": {
-                "spacing": 20,
-                "length": 100,
-                "colour": "rgba(107, 79, 118, 0.10)",
-                "snap": true
+                "spacing": 30,
+                "length": 1,
+                "colour": "rgb(189, 195, 199)",
+                "snap": false
             }
         },
         "blockColors": {
@@ -624,7 +624,7 @@
         "simAnimationExit": "fly right out",
         "crowdinProject": "makecode",
         "monacoColors": {
-            "editor.background": "#FEF3E0"
+            "editor.background": "#F8FAFC"
         },
         "monacoFieldEditors": [
             "image-editor",

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -31,21 +31,23 @@
 @grey             : #7f8c8d;
 @orange           : #F76820;
 @pink             : #E91E63;
-@teal             : #028B9B;
+@teal             : #116E79;
 @yellow           : #f1c40f;
 
 /* 32 colors */
-@purple           : #6B4F76;
+@purple           : #5D4FBA;
 @blue             : #B1E3DA;
 @beige            : #FEF3E0;
 @salmon           : #E95153;
+
+@lightGrey        : #F8FAFC;
 
 /*-------------------
     Brand Colors
 --------------------*/
 
-@primaryColor        : @orange;
-@secondaryColor      : @orange;
+@primaryColor        : @teal;
+@secondaryColor      : @purple;
 
 @lightPrimaryColor   : @lightBlue;
 @lightSecondaryColor : @lightGrey;
@@ -61,9 +63,9 @@
    Menu
 --------------------*/
 
-@mainMenuInvertedBackground: @orange;
+@mainMenuInvertedBackground: @teal;
 @mainMenuTutorialBackground: @teal;
-@mainMenuTutorialButtons: @orange;
+@mainMenuTutorialButtons: @teal;
 
 @mainMenuBlocksJsToggleColor: @primaryColor;
 
@@ -81,10 +83,10 @@
    Background
 --------------------*/
 
-@simulatorBackground: @blue;
-@editorToolsBackground: @beige;
-@blocklySvgColor: @beige;
-@homeScreenBackground: @beige;
+@simulatorBackground: @lightSecondaryColor;
+@editorToolsBackground: @lightSecondaryColor;
+@blocklySvgColor: @lightSecondaryColor;
+@homeScreenBackground: @lightSecondaryColor;
 @cloudCardBackground: lighten(desaturate(@teal, 56), 23);
 
 /*-------------------
@@ -98,7 +100,7 @@
    Editor
 --------------------*/
 
-@blocklyToolboxColor: @beige;
+@blocklyToolboxColor: @white;
 @trashIconColor: @primaryColor;
 
 /*-------------------

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -87,7 +87,7 @@
 @editorToolsBackground: @lightSecondaryColor;
 @blocklySvgColor: @lightSecondaryColor;
 @homeScreenBackground: @lightSecondaryColor;
-@cloudCardBackground: lighten(desaturate(@teal, 56), 23);
+@cloudCardBackground: darken(@secondaryColor, 20%);
 
 /*-------------------
    Full screen
@@ -140,3 +140,6 @@
 @teachingBubbleBackgroundColor: @teal;
 @teachingBubbleTextColor: @white;
 @teachingBubbleStepsColor: @beige;
+
+@assetUnselected: #ebedef;
+@DebuggerBackgroundPrimaryColor: #117955;

--- a/theme/site/views/card.overrides
+++ b/theme/site/views/card.overrides
@@ -1,3 +1,7 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+.ui.card.link.newprojectcard {
+    background: @secondaryColor !important;
+}

--- a/theme/style.less
+++ b/theme/style.less
@@ -81,6 +81,22 @@
     stroke: @soundEffectHeaderColor;
 }
 
+.carouselarrow {
+    color: @secondaryColor;
+}
+
+.projectsdialog .detailview .ui.grid.stackable .actions .card-action .button.approve {
+    background-color: @primaryColor;
+}
+
+.extensions-browser {
+    .extension-tag.selected {
+        background-color: @primaryColor;
+        border-color: @primaryColor;
+        color: @white
+    }
+}
+
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
 }

--- a/theme/style.less
+++ b/theme/style.less
@@ -53,15 +53,15 @@
 }
 
 .ui.primary.button.download-button {
-    background-color: @orange;
+    background-color: @secondaryColor;
 }
 
 .simtoolbar .ui.button.icon, #editortools .ui.button.editortools-btn {
-    background-color: @teal;
+    background-color: @secondaryColor;
 }
 
 #editortools .ui.button.hw-button {
-    background-color: darken(desaturate(@orange, 20%), 10%);
+    background-color: darken(@secondaryColor, 15%);
 }
 
 #simulator .ui.button.play-button .icon.play {


### PR DESCRIPTION
Arcade's orange does not allow for accessible contrast. We could try to darken it, but that would not create a desirable color, so we've decided to update the arcade theme.

Fixes https://github.com/microsoft/pxt-microbit/issues/5469
Fixes https://github.com/microsoft/pxt-arcade/issues/3973
Fixes https://github.com/microsoft/pxt-microbit/issues/5465

Please play around with this! I think it will be good to use a testing session for everyone to get a feel with it, but there are a lot of spots that have different styling, so there might be something that I missed. Note that the "New? Start Here" labels are orange right now because the color is changed in docs. https://arcade.makecode.com/app/3e33481bd3886ff462d55b14af25a3360e2a0402-0e60e79eaf#