### PR TITLE
Color update: put the new try this banners back to orange

### DIFF
--- a/docs/beginner-maps.md
+++ b/docs/beginner-maps.md
@@ -14,7 +14,7 @@
   "imageUrl":  "/static/skillmap/backgrounds/story-map.png",
   "url": "https://arcade.makecode.com/--skillmap#story",
   "label": "New? Try This!",
-  "labelClass": "purple ribbon large",
+  "labelClass": "orange ribbon large",
   "directOpen": true
 },
 {

--- a/docs/skillmaps.md
+++ b/docs/skillmaps.md
@@ -12,7 +12,7 @@
   "imageUrl":  "/static/skillmap/backgrounds/beginner.png",
   "url": "https://arcade.makecode.com/--skillmap#beginner",
   "label": "New? Try This!",
-  "labelClass": "purple ribbon large",
+  "labelClass": "orange ribbon large",
   "directOpen": true
 },
 {

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -14,7 +14,7 @@
   "imageUrl": "/static/tutorials/interface/info.png",
   "largeImageUrl": "/static/tutorials/interface/info.png",
   "label": "New? Try This!",
-  "labelClass": "purple ribbon large"
+  "labelClass": "orange ribbon large"
 },{
   "name": "Chase the Pizza",
   "description": "Get started creating a simple game to chase a pizza around the screen and collect as many points as possible before time runs out!",


### PR DESCRIPTION
I changed the "New? Try This!" banners to be the purple color for the color updates for arcade, but since these changes are in docs, the change is live. We need the color to go back to orange for now. 