### PR TITLE
[stable1.12 hotfix] bumping pxt-core, common-packages for user high scores on kiosk

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "10.3.25",
-        "pxt-core": "8.5.63"
+        "pxt-common-packages": "10.3.26",
+        "pxt-core": "8.5.65"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.11"


### PR DESCRIPTION
The changes that will take effect are outlined in these PRs: 

In pxt: https://github.com/microsoft/pxt/commit/0425ce8e836b700256a54b27b0ea83b46067cf79

In common packages: https://github.com/microsoft/pxt-common-packages/commit/1c2be247ea57f7718604daa94e69707b07e635b5