### PR TITLE
Fix mismatch errors for block names in tutorials.

### DIFF
--- a/docs/tutorials/galga.md
+++ b/docs/tutorials/galga.md
@@ -365,7 +365,7 @@ game.onUpdateInterval(1000, function () {
 
 ---
 
-► Grab a ``||sprites:set [mySprite] position to vx [0] vy [0]||`` block
+► Grab a ``||sprites:set [mySprite] position to x [0] y [0]||`` block
 and snap it into the end of your **on game update** block. Change **mySprite**
 to **bogey**.
 

--- a/docs/tutorials/simple-extensions.md
+++ b/docs/tutorials/simple-extensions.md
@@ -61,7 +61,7 @@ let myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
 myCorg.verticalMovement()
 myCorg.updateSprite()
-myCorg.follow()
+myCorg.cameraFollow()
 tiles.setTilemap(tilemap`level_0`)
 ```
 
@@ -75,7 +75,7 @@ let myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
 myCorg.verticalMovement()
 myCorg.updateSprite()
-myCorg.follow()
+myCorg.cameraFollow()
 tiles.setTilemap(tilemap`level_1`)
 ```
 
@@ -94,7 +94,7 @@ let myCorg = corgio.create(SpriteKind.Player)
 myCorg.horizontalMovement()
 myCorg.verticalMovement()
 myCorg.updateSprite()
-myCorg.follow()
+myCorg.cameraFollow()
 tiles.setTilemap(tilemap`level_1`)
 ```
 


### PR DESCRIPTION
The "Simple Extension" tutorial was referring to `corgi.follow()` instead of the updated api of `corgi.cameraFollow()`, see #4820.

The "Galga" blocks tutorial mentioned the sprite position block using parameters of `vx` and `vy` rather than `x` and `y` as it should have.