### PR TITLE
Remove open as tutorial links

### DIFF
--- a/docs/concepts/bouncing-burger.md
+++ b/docs/concepts/bouncing-burger.md
@@ -1,7 +1,5 @@
 # Bouncing Burger
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/bouncing-burger)
-
 ## {Introduction @unplugged}
 
 ``||sprites:Sprites||`` can be given ``||sprites:x||`` and ``||sprites:y||`` velocities so that they can move around the screen.  In this case, a ``||sprites:Sprite||`` will be used to represent a burger that bounces around the screen.

--- a/docs/concepts/picnic-food.md
+++ b/docs/concepts/picnic-food.md
@@ -1,7 +1,5 @@
 # Picnic Food
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/picnic-food)
-
 ## {Introduction @unplugged}
 
 ``||sprites:Sprites||`` can be placed in different locations around the screen. This is done by setting their ``||sprites:x||`` and ``||sprites:y||`` positions.

--- a/docs/concepts/princess-pizza.md
+++ b/docs/concepts/princess-pizza.md
@@ -1,7 +1,5 @@
 # Princess Pizza
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/princess-pizza)
-
 ## {Introduction @unplugged}
 
 ``||sprites:Sprites||`` that are moving will often have situations where two sprites end up on top of each other. The ``||sprites:sprite overlap||`` event can be used to handle interactions between ``||sprites:sprites||`` when this occurs.

--- a/docs/concepts/setting-the-scene.md
+++ b/docs/concepts/setting-the-scene.md
@@ -1,7 +1,5 @@
 # Setting the Scene
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/setting-the-scene)
-
 ## {Introduction @unplugged}
 
 The maps and levels in a game are important to make the game interesting to explore. ``||scene:Tilemaps||`` are used to create maps for the player to explore, which can even be set to prevent the player from moving past certain points.

--- a/docs/concepts/sunday-drive.md
+++ b/docs/concepts/sunday-drive.md
@@ -1,7 +1,5 @@
 # Sunday Drive
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/sunday-drive)
-
 ## {Introduction @unplugged}
 
 Games often need actions to occur repeatedly - enemies and collectibles need to be created, winning conditions need to be checked, and so on. The ``||game:on game update interval||`` event allows you to set code to run on a set time period, so that it will occur repeatedly.

--- a/docs/concepts/throw-a-bone.md
+++ b/docs/concepts/throw-a-bone.md
@@ -1,7 +1,5 @@
 # Throw a Bone
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/throw-a-bone)
-
 ## {Introduction @unplugged}
 
 Setting up ``||sprites:Sprites||`` can get a bit complicated, with a number of different blocks. ``||sprites:Projectiles||`` are special ``||sprites:Sprites||`` that are made to move across the screen and simplify these sorts of behaviors for you.

--- a/docs/concepts/walking-hero.md
+++ b/docs/concepts/walking-hero.md
@@ -1,7 +1,5 @@
 # Walking Hero
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/walking-hero)
-
 ## {Introduction @unplugged}
 
 ``||sprites:Sprites||`` can be used to represent the **characters** in your game. These can be anything - coins to collect, enemies to avoid, or lasers fired from a spaceship.

--- a/docs/concepts/which-button.md
+++ b/docs/concepts/which-button.md
@@ -1,7 +1,5 @@
 # Which Button?
 
-[Open this tutorial in the editor!](/#tutorial:/concepts/which-button)
-
 ## {Introduction @unplugged}
 
 The ``||info:Info||`` category has a number of properties that help handle common behaviors in games. By default, these properties show up on screen as soon as they are set, allowing for an easy way to give the people playing your game information about how well they are doing.


### PR DESCRIPTION
Since the sidedocs view wants to stick `doc:` in here, the simple thing to do is to just remove the "Open this as a tutorial in the editor" links.

Otherwise, we can change the sidedocs open link logic. It currently does this:

`https://arcade.makecode.com/---docs#doc:#tutorial:/concepts/walking-hero`

Closes #6604