### PR TITLE
Remove 'try as tutorial' link/button for docview

### DIFF
--- a/docs/tutorials/catch-the-football.md
+++ b/docs/tutorials/catch-the-football.md
@@ -1,11 +1,5 @@
 # Catch the Football
 
-### ~button /#tutorial:/tutorials/catch-the-football
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @unplugged}
 
 ![Game animation](/static/tutorials/catch-the-football.gif)

--- a/docs/tutorials/chase-the-basketball.md
+++ b/docs/tutorials/chase-the-basketball.md
@@ -1,11 +1,5 @@
 # Chase the Basketball
 
-### ~button /#tutorial:/tutorials/chase-the-basketball
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @unplugged}
 
 ![Game animation](/static/tutorials/chase-the-basketball.gif)

--- a/docs/tutorials/chase-the-pizza.md
+++ b/docs/tutorials/chase-the-pizza.md
@@ -1,13 +1,6 @@
 # Chase the Pizza
 ### @explicitHints true
 
-
-### ~button /#tutorial:/tutorials/chase-the-pizza
-
-Try this tutorial!
-
-### ~
-
 ## Introduction @showdialog
 
 ![Game animation](/static/tutorials/chase-the-pizza/chasing.gif)

--- a/docs/tutorials/collect-the-clovers.md
+++ b/docs/tutorials/collect-the-clovers.md
@@ -1,12 +1,6 @@
 # Collect the Clovers
 ### @explicitHints true
 
-### ~button /#tutorial:/tutorials/collect-the-clovers
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @showdialog}
 
 Create a garden game to collect 4-leaf clovers and avoid the bees!

--- a/docs/tutorials/football.md
+++ b/docs/tutorials/football.md
@@ -1,11 +1,5 @@
 # Mod the Football
 
-### ~button /#tutorial:/tutorials/football
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @unplugged}
 
 ![Game animation](/static/tutorials/football/header.gif)

--- a/docs/tutorials/galga.md
+++ b/docs/tutorials/galga.md
@@ -1,11 +1,5 @@
 # Galga
 
-### ~button /#tutorial:/tutorials/galga
-
-Try this tutorial!
-
-### ~
-
 ### @autoexpandOff true
 
 ## {Introduction @unplugged}

--- a/docs/tutorials/happy-flower.md
+++ b/docs/tutorials/happy-flower.md
@@ -1,11 +1,5 @@
 # Happy Flower
 
-### ~button /#tutorial:/tutorials/happy-flower
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @unplugged}
 
 Flowers make everyone around them happier, especially the bees who get nectar from them. To show this, we can create a flower that sends happy little bees back to the hive.

--- a/docs/tutorials/lander.md
+++ b/docs/tutorials/lander.md
@@ -1,11 +1,5 @@
 # Lander
 
-### ~button /#tutorial:/tutorials/lander
-
-Let's create a lunar landing game!
-
-### ~
-
 ## {Introduction @unplugged}
 
 ![Game animation](/static/tutorials/lander.gif)

--- a/docs/tutorials/lemon-leak.md
+++ b/docs/tutorials/lemon-leak.md
@@ -1,11 +1,5 @@
 # Lemon Leak
 
-### ~button /#tutorial:/tutorials/lemon-leak
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @unplugged}
 
 ![Game animation](/static/tutorials/lemon-leak.gif)

--- a/docs/tutorials/maze.md
+++ b/docs/tutorials/maze.md
@@ -1,11 +1,5 @@
 # Maze
 
-### ~button /#tutorial:/tutorials/maze
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @unplugged}
 
 Welcome to @boardname@! Let's get started by creating a game where your player tries to get out of a maze while there's still time!

--- a/docs/tutorials/spy/galga.md
+++ b/docs/tutorials/spy/galga.md
@@ -1,11 +1,5 @@
 # Galga
 
-### ~button /#tutorial:/tutorials/galga
-
-Try this tutorial!
-
-### ~
-
 ## {Introduction @unplugged}
 
 Fly your space plane through the oncoming bogey spacecraft. Can you survive the continuous attack? You start with three lives but you gain more by firing on the enemy ships. You lose a life with every collision, so try to blast away the enemy before they hit you.


### PR DESCRIPTION
Remove the "Try this tutorial" button/links due to malformed URL's when opened in sidedocs vs. docs view. If it's desired to keep these, then we could modify the open url logic in the render.

![image](https://github.com/user-attachments/assets/db511f22-1799-485d-a476-8029016464ae)

Erroneous URL formed from sidedocs view:

https://arcade.makecode.com/---docs#doc:#tutorial:/tutorials/chase-the-pizza

...from markdown:

```
### ~button /#tutorial:/tutorials/chase-the-pizza

Try this tutorial!

### ~
```

RE: https://github.com/microsoft/pxt-arcade/issues/6604#issuecomment-2630069473