### PR TITLE
remove share tech mono

### DIFF
--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -12,14 +12,14 @@
      Fonts
 --------------------*/
 
-@headerFont        : "Share Tech Mono", Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
-@pageFont          : "Share Tech Mono", Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+@headerFont        : 'Segoe UI', 'Segoe UI Web (West European)', -apple-system, BlinkMacSystemFont, Roboto, 'Helvetica Neue', sans-serif;
+@pageFont          : 'Segoe UI', 'Segoe UI Web (West European)', -apple-system, BlinkMacSystemFont, Roboto, 'Helvetica Neue', sans-serif;
 
-@docsHeaderFont: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-@docsPageFont: 'Helvetica Neue', Arial, Helvetica, sans-serif;
+@docsHeaderFont: 'Segoe UI', 'Segoe UI Web (West European)', -apple-system, BlinkMacSystemFont, Roboto, 'Helvetica Neue', sans-serif;
+@docsPageFont: 'Segoe UI', 'Segoe UI Web (West European)', -apple-system, BlinkMacSystemFont, Roboto, 'Helvetica Neue', sans-serif;
 
 @importGoogleFonts: false;
-@fontName: "Share Tech Mono";
+@fontName: "Segoe UI";
 
 /*-------------------
       Site Colors

--- a/theme/style.less
+++ b/theme/style.less
@@ -13,15 +13,6 @@
     Add your custom CSS here
 *******************************/
 
-/* Open Sans font */
-@font-face {
-    font-family: 'Share Tech Mono';
-    font-style: normal;
-    font-weight: 400;
-    src: local('Share Tech Mono'),
-         data-uri('../docs/static/fonts/ShareTechMono-Regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
-}
-
 .simtoolbar .ui.button,
 .ui.button.play-button,
 .ui.button.restart-button,
@@ -95,6 +86,10 @@
         border-color: @primaryColor;
         color: @white
     }
+}
+
+span.blocklyTreeLabel {
+    font-weight: 500;
 }
 
 /* Mobile */


### PR DESCRIPTION
replaces share tech mono with the standard microsoft font string. no more annoying monospace font!

look how much better it looks:

![image](https://github.com/user-attachments/assets/fdc5a918-9e2f-4c24-a1c0-b501461aacca)
