### PR TITLE
Update Secondary Accent Colors for Arcade

### DIFF
--- a/theme/color-themes/arcade-dark.json
+++ b/theme/color-themes/arcade-dark.json
@@ -23,7 +23,7 @@
         "pxt-secondary-foreground": "#f3f2f1",
         "pxt-secondary-background-hover": "#742e80",
         "pxt-secondary-foreground-hover": "#f3f2f1",
-        "pxt-secondary-accent": "#63276d",
+        "pxt-secondary-accent": "#411a47",
 
         "pxt-tertiary-background": "#0078d4",
         "pxt-tertiary-foreground": "#ffffff",

--- a/theme/color-themes/arcade-legacy.json
+++ b/theme/color-themes/arcade-legacy.json
@@ -20,7 +20,7 @@
         "pxt-secondary-background-hover": "#015e69",
         "pxt-secondary-foreground": "#FFFFFF",
         "pxt-secondary-foreground-hover": "#FFFFFF",
-        "pxt-secondary-accent": "#01474f",
+        "pxt-secondary-accent": "#015964",
 
         "pxt-tertiary-background": "#028B9B",
         "pxt-tertiary-foreground": "#FFFFFF",

--- a/theme/color-themes/arcade-legacy.json
+++ b/theme/color-themes/arcade-legacy.json
@@ -20,7 +20,7 @@
         "pxt-secondary-background-hover": "#015e69",
         "pxt-secondary-foreground": "#FFFFFF",
         "pxt-secondary-foreground-hover": "#FFFFFF",
-        "pxt-secondary-accent": "#58afba",
+        "pxt-secondary-accent": "#01474f",
 
         "pxt-tertiary-background": "#028B9B",
         "pxt-tertiary-foreground": "#FFFFFF",

--- a/theme/color-themes/arcade-light.json
+++ b/theme/color-themes/arcade-light.json
@@ -2,7 +2,8 @@
     "id": "arcade-light",
     "name": "Arcade Light",
     "weight": 40,
-    "overrideFiles": [],
+    "overrideFiles": [
+        "/overrides/arcade-light-overrides.css"],
     "colors": {
         "pxt-header-background": "#116E79",
         "pxt-header-foreground": "#FFFFFF",
@@ -20,7 +21,7 @@
         "pxt-secondary-foreground": "#F8FAFC",
         "pxt-secondary-background-hover": "#483c9a",
         "pxt-secondary-foreground-hover": "#F8FAFC",
-        "pxt-secondary-accent": "#7569c4",
+        "pxt-secondary-accent": "#403587",
 
         "pxt-tertiary-background": "#116E79",
         "pxt-tertiary-foreground": "#FFFFFF",

--- a/theme/color-themes/overrides/arcade-light-overrides.css
+++ b/theme/color-themes/overrides/arcade-light-overrides.css
@@ -1,0 +1,5 @@
+.gallerysegment .ui.card.link.cloudprojectscard {
+    /* Differentiate from New Project button */
+    background-color: var(--pxt-colors-teal-background) !important;
+    color: var(--pxt-colors-teal-foreground) !important;
+}


### PR DESCRIPTION
The secondary-accent color was previously only used for the "cloud projects" card, but with https://github.com/microsoft/pxt/pull/10424, we now use it for the active sim toolbar buttons instead. As a result, having a darker shade instead of a lighter shade feels more natural.

Meanwhile, the "cloud projects" card can just use the normal secondary color, but arcade-light needs an override, since in that theme, primary = secondary.

Upload target: https://arcade.makecode.com/app/a2b90411277dc31bf416b4bc830035728af40d75-0cd92e0a68