### PR TITLE
Theme Renaming and Fixes

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -621,7 +621,7 @@
             "arrays": "#FF8F08",
             "functions": "#1446A0"
         },
-        "defaultColorTheme": "arcade-legacy",
+        "defaultColorTheme": "arcade-orange",
         "highContrastColorTheme": "pxt-high-contrast",
         "simAnimationEnter": "fly right in",
         "simAnimationExit": "fly right out",

--- a/theme/color-themes/arcade-dark.json
+++ b/theme/color-themes/arcade-dark.json
@@ -1,6 +1,6 @@
 {
     "id": "arcade-dark",
-    "name": "Arcade Dark",
+    "name": "Dark",
     "weight": 60,
     "monacoBaseTheme": "vs-dark",
     "overrideFiles": [

--- a/theme/color-themes/arcade-light.json
+++ b/theme/color-themes/arcade-light.json
@@ -1,6 +1,6 @@
 {
     "id": "arcade-light",
-    "name": "Arcade Light",
+    "name": "Light",
     "weight": 40,
     "overrideFiles": [
         "/overrides/arcade-light-overrides.css"],

--- a/theme/color-themes/arcade-orange.json
+++ b/theme/color-themes/arcade-orange.json
@@ -1,6 +1,6 @@
 {
-    "id": "arcade-legacy",
-    "name": "Arcade Legacy",
+    "id": "arcade-orange",
+    "name": "Orange",
     "weight": 20,
     "overrideFiles": [],
     "colors": {

--- a/theme/color-themes/overrides/arcade-dark-overrides.css
+++ b/theme/color-themes/overrides/arcade-dark-overrides.css
@@ -5,7 +5,7 @@
 
 #langmodal #availablelocales .langoption .header {
     /* Better contrast than default, which is purple */
-    color: var(--pxt-colors-teal-background);
+    color: var(--pxt-neutral-foreground1);
 }
 
 .pxtToolbox span.blocklyTreeLabel,

--- a/theme/color-themes/overrides/arcade-dark-overrides.css
+++ b/theme/color-themes/overrides/arcade-dark-overrides.css
@@ -50,12 +50,12 @@
 }
 
 /* For inverted buttons, it almost always looks better to have the background be dark instead of light (even though non-inverted has a light foreground) */
-button.ui.button.inverted,
-button.common-button.inverted {
+button.ui.button.inverted:not(.teaching-bubble-button),
+button.common-button.inverted:not(.teaching-bubble-button) {
     background-color: var(--pxt-neutral-background2) !important;
 }
 
-button.ui.button.inverted:hover,
-button.common-button.inverted:hover {
+button.ui.button.inverted:hover:not(.teaching-bubble-button),
+button.common-button.inverted:hover:not(.teaching-bubble-button) {
     background-color: var(--pxt-neutral-background2-hover) !important;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6814
- Rename themes to remove "Aracde" (i.e. "Arcade Light" -> "Light")
- Rename "Legacy" to "Orange" (normally, we shouldn't change ids, but since it hasn't shipped yet, I think it's fine for now)

Fixes https://github.com/microsoft/pxt-arcade/issues/6813
- Change language headers to white instead of teal

Fixes https://github.com/microsoft/pxt-arcade/issues/6807
- Do not apply the dark-theme inverted button override to teaching bubble buttons
- Depends on pxt change to add ids (https://github.com/microsoft/pxt/pull/10436)

Upload target: https://arcade.makecode.com/app/806ccd6ac700307751a9a55c0f3bdd0143e45dd4-5c060effad