### PR TITLE
Update "ask for string/number" upgrade rule to reflect new default parameter

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.13
+          ref: v0.11.14
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: microsoft/pxt-arcade-sim
-          ref: v0.11.13
+          ref: v0.11.14
           token: ${{ secrets.GH_TOKEN }}
           path: node_modules/pxt-arcade-sim
       - name: pxt ci

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -363,7 +363,7 @@ namespace pxt.editor {
 
                     const field = document.createElement("field");
                     field.setAttribute("name", "BOOL");
-                    field.textContent = "TRUE";
+                    field.textContent = "FALSE";
 
                     shadow.appendChild(field);
                     value.appendChild(shadow);
@@ -397,18 +397,6 @@ namespace pxt.editor {
                     value.appendChild(shadow);
                     block.appendChild(value);
                 }
-
-                // alter the mutation so that the block is fully expanded. this is required
-                // to make sure that the parameters we added take effect
-                let mutation = getMutation(block);
-                if (!mutation) {
-                    mutation = document.createElement("mutation");
-                    mutation.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
-                    block.appendChild(mutation);
-                }
-
-                mutation.setAttribute("_expanded", "2");
-                mutation.setAttribute("_input_init", "true");
             }
         }
     }

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -342,29 +342,73 @@ namespace pxt.editor {
             performOldEnumShimUpgrade("SpriteKindLegacy", "spritetype");
         }
 
-        // Added the "use system keyboard" options to the ask for number and ask for string blocks
-        if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "2.0.18") < 0) {
+        // Added the "use on-screen keyboard" options to the ask for number and ask for string blocks
+        if (pxt.semver.strcmp(pkgTargetVersion || "0.0.0", "2.0.35") < 0) {
             const allPromptBlocks = U.toArray(dom.querySelectorAll("block[type=gameaskforstring]"))
                 .concat(U.toArray(dom.querySelectorAll("shadow[type=gameaskforstring]")))
                 .concat(U.toArray(dom.querySelectorAll("block[type=gameaskfornumber]")))
                 .concat(U.toArray(dom.querySelectorAll("shadow[type=gameaskfornumber]")));
 
             for (const block of allPromptBlocks) {
-                if (!getChildNode(block, "value", "name", "useSystemKeyboard")) {
+                if (getChildNode(block, "value", "name", "useOnScreenKeyboard")) {
+                    continue;
+                }
+                else {
+                    // preserve the old behavior by setting the value to true if not present
                     const value = document.createElement("value");
-                    value.setAttribute("name", "useSystemKeyboard");
+                    value.setAttribute("name", "useOnScreenKeyboard");
 
                     const shadow = document.createElement("shadow");
                     shadow.setAttribute("type", "logic_boolean");
 
                     const field = document.createElement("field");
                     field.setAttribute("name", "BOOL");
-                    field.textContent = "FALSE";
+                    field.textContent = "TRUE";
 
                     shadow.appendChild(field);
                     value.appendChild(shadow);
                     block.appendChild(value);
                 }
+
+                // since we are going to expand the block, we also need to make sure that
+                // the other expandable parameter answerLength is present. the default values
+                // and min/max were taken from the source in pxt-common-packages prior to this change
+                const isStringBlock = block.getAttribute("type") === "gameaskforstring";
+                if (!getChildNode(block, "value", "name", "answerLength")) {
+                    const value = document.createElement("value");
+                    value.setAttribute("name", "answerLength");
+
+                    const shadow = document.createElement("shadow");
+                    shadow.setAttribute("type", "math_number_minmax");
+
+                    const mutation = document.createElement("mutation");
+                    mutation.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+                    mutation.setAttribute("min", "1");
+                    mutation.setAttribute("max", isStringBlock ? "24" : "10");
+                    mutation.setAttribute("label", "AnswerLength");
+                    mutation.setAttribute("prevision", "0");
+
+                    const field = document.createElement("field");
+                    field.setAttribute("name", "SLIDER");
+                    field.textContent = isStringBlock ? "12" : "6";
+
+                    shadow.appendChild(field);
+                    shadow.appendChild(mutation);
+                    value.appendChild(shadow);
+                    block.appendChild(value);
+                }
+
+                // alter the mutation so that the block is fully expanded. this is required
+                // to make sure that the parameters we added take effect
+                let mutation = getMutation(block);
+                if (!mutation) {
+                    mutation = document.createElement("mutation");
+                    mutation.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+                    block.appendChild(mutation);
+                }
+
+                mutation.setAttribute("_expanded", "2");
+                mutation.setAttribute("_input_init", "true");
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "12.2.7",
+        "pxt-common-packages": "12.2.9",
         "pxt-core": "11.3.43"
     },
     "optionalDependencies": {
-        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.13"
+        "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.14"
     },
     "scripts": {
         "serve": "node node_modules/pxt-core/built/pxt.js serve",


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6810

this updates the upgrade rule so that we now expand the ask for string/number blocks and set the onScreenKeyboard option to true when upgrading older projects.

for example, this project from live:

![arcade-screenshot (65)](https://github.com/user-attachments/assets/c09a452c-5bfe-469d-9583-a47607a8bc0a)

will upgrade to this project:

![arcade-screenshot (66)](https://github.com/user-attachments/assets/fe54fb51-e6c1-4e05-9c25-e05ad374199f)

12 and 6 are the default values for the answerLength parameter