### PR TITLE
Hide the radio raiseEvent block

### DIFF
--- a/libs/device/pxt.json
+++ b/libs/device/pxt.json
@@ -10,6 +10,7 @@
         "smallFood.ts",
         "bigFood.jres",
         "bigFood.ts",
+        "radio.d.ts",
         "sprites.duck.jres",
         "sprites.duck.ts",
         "sprites.castle.jres",

--- a/libs/device/radio.d.ts
+++ b/libs/device/radio.d.ts
@@ -1,0 +1,7 @@
+declare namespace radio {
+    /**
+     * Sends an event over radio to neigboring devices
+     */
+    //% blockHidden=1 shim=radio::raiseEvent
+    function raiseEvent(src: int32, value: int32): void;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4860