### PR TITLE
Invert images for the dark theme workspace search buttons

### DIFF
--- a/theme/color-themes/overrides/arcade-dark-overrides.css
+++ b/theme/color-themes/overrides/arcade-dark-overrides.css
@@ -34,7 +34,10 @@
 /* 
  * Inverted image colors
  */
-.barcharticon {
+.barcharticon,
+.blockly-ws-search-next-btn,
+.blockly-ws-search-previous-btn,
+.blockly-ws-search-close-btn {
     filter: invert(1);
 }
 


### PR DESCRIPTION
Needed so the buttons in blockly workspace search are visible after https://github.com/microsoft/pxt/pull/10448