### PR TITLE
add alternate category for a 'set to sprite' highlight

### DIFF
--- a/docs/tutorials/froggy.md
+++ b/docs/tutorials/froggy.md
@@ -47,7 +47,7 @@ scene.setBackgroundImage(flies_imgs.background)
 ---
 
 - :paper plane: From ``||sprites:Sprites||``, drag<br/>
-``||variables:set [frog] to sprite [ ] of kind [Player]||``<br/>
+``||variables(sprites):set [frog] to sprite [ ] of kind [Player]||``<br/>
 into **the end** of the<br/>
 ``||loops(noclick):on start||`` container.
 


### PR DESCRIPTION
Add an alternate category to open in the `variables` highlight for `set [frog] to sprite`.

Closes #6242