### PR TITLE
Port to Stable: Invert images for the workspace search buttons in dark theme (#6850)

### DIFF
--- a/theme/color-themes/overrides/arcade-dark-overrides.css
+++ b/theme/color-themes/overrides/arcade-dark-overrides.css
@@ -34,7 +34,10 @@
 /* 
  * Inverted image colors
  */
-.barcharticon {
+.barcharticon,
+.blockly-ws-search-next-btn,
+.blockly-ws-search-previous-btn,
+.blockly-ws-search-close-btn {
     filter: invert(1);
 }
 


### PR DESCRIPTION
Port of https://github.com/microsoft/pxt-arcade/pull/6850 (https://github.com/microsoft/pxt-arcade/commit/89bec11852fb7a9b87c7bdb8e5044c5d38741938)