### PR TITLE
Remove comments from 'blockconfig' in 'Blazing Glory' tutorial

### DIFF
--- a/docs/tutorials/blazing.md
+++ b/docs/tutorials/blazing.md
@@ -339,7 +339,6 @@ This will remove a life from the group whenever a projectile overlaps a player.
 
 
 ```blockconfig.local
-//@highlight
 sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Player, function (sprite, otherSprite) {
     sprites.destroy(sprite, effects.fire, 100)
     info.changeLifeBy(-1)


### PR DESCRIPTION
Remove the comments from `blockconfig` in the tutorial so they won't appear in the toolbox blocks.

Closes #6852