### PR TITLE
Update pxtarget.json to disable vscode for ninja config

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -713,7 +713,8 @@
                 "embeddedTutorial": true,
                 "allowParentController": true,
                 "shareFinishedTutorials": false,
-                "hideReplaceMyCode": false
+                "hideReplaceMyCode": false,
+                "showOpenInVscode": false
             }
         }
     },


### PR DESCRIPTION
Within the Code Ninjas impact site, the share functionality of games is non-functional (as the pxt.json is missing information required for sharing). It is not possible to fix this for a large majority of projects, as access to the pxt.json file is not permitted within the blocks editor.

Currently, clicking the button will log an error to the console without any visual indicator to the user. Because of this, the "open in vscode" button should be hidden to not introduce unnecessary confusion when it doesn't work as intended.