### PR TITLE
add pxtjson option to enable asset packs

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -691,7 +691,14 @@
         "timeMachineSnapshotInterval": 1800000,
         "feedbackEnabled": true,
         "ocvAppId": 50315,
-        "ocvFrameUrl": "https://admin-ignite.microsoft.com"
+        "ocvFrameUrl": "https://admin-ignite.microsoft.com",
+        "pxtJsonOptions": [
+            {
+                "label": "Import as asset pack",
+                "property": "assetPack",
+                "type": "checkbox"
+            }
+        ]
     },
     "queryVariants": {
         "skillmap=1": {


### PR DESCRIPTION
requires https://github.com/microsoft/pxt/pull/10525 but safe to merge without it!

this adds the below setting for enabling the assetPack flag in pxt.json:

![image](https://github.com/user-attachments/assets/c6e74ab7-3850-4883-9a66-56f25b676260)
