### PR TITLE
[stable2.0] Revert "bump pxt-core to 11.3.57 and pxt-common-packages to 12.2.14"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "12.2.14",
-        "pxt-core": "11.3.57"
+        "pxt-common-packages": "12.2.13",
+        "pxt-core": "11.3.54"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.17"


### PR DESCRIPTION
This reverts commit f00c6f6970d78fa9df0dfbef8107e10f67a11a32.