### PR TITLE
Update pxt-core to 11.3.58 and pxt-common-packages to 12.2.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
         "typescript": "4.8.3"
     },
     "dependencies": {
-        "pxt-common-packages": "12.2.12",
-        "pxt-core": "11.3.51"
+        "pxt-common-packages": "12.2.14",
+        "pxt-core": "11.3.58"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.16"


### PR DESCRIPTION
moving common-packages and core back to where they were for the hotfix plus the fix in https://github.com/microsoft/pxt/pull/10532