### PR TITLE
Update links for the new Stencilr site

### DIFF
--- a/docs/arts-and-crafts.md
+++ b/docs/arts-and-crafts.md
@@ -40,4 +40,4 @@ into real world art! Please drop us a message if you know another tool to be add
 * [LEGO Bricks Murals](/arts-and-crafts/lego-bricks-murals)
 * [Laser-cut Stencils](/arts-and-crafts/laser-cut-stencils)
 * [Perler Bead Sprites](/arts-and-crafts/perler-bead-sprites)
-* [Arcade Stencilr](https://arcade-stencils.glitch.me/)
+* [Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/)

--- a/docs/arts-and-crafts/laser-cut-stencils.md
+++ b/docs/arts-and-crafts/laser-cut-stencils.md
@@ -8,7 +8,7 @@ t-shirts, boards, walls, etc... You will need access to a laser cutter.
 * open the sprite you want to turn into stencils
 * select the image area you want to recreate with the **Marquee** tool
 * press Ctrl+C or Command+C to copy the image in the clipboard
-* open [MakeCode Arcade Stencilr](https://arcade-stencils.glitch.me/) (on glitch.me).
+* open [MakeCode Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/) (on GitHub pages).
 * press Ctrl+V or Command+V to paste the image in the image text box
 * download the **DXF** for each layer
 * cut out each layer into a stencil

--- a/docs/arts-and-crafts/lego-bricks-murals.md
+++ b/docs/arts-and-crafts/lego-bricks-murals.md
@@ -7,7 +7,7 @@ With this **Arcade Stencilr** you will be able to take your pixel art painted in
 * open the sprite you want to recreate with LEGO
 * select the image area you want to recreate with the **Marquee** tool
 * press Ctrl+C or Command+C to copy the image in the clipboard
-* open [MakeCode Arcade Stencilr](https://arcade-stencils.glitch.me/) (on glitch.me).
+* open [MakeCode Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/) (on GitHub pages).
 * press Ctrl+V or Command+V to paste the image in the image text box
 * download the LEGO instructions and have fun!
 

--- a/docs/arts-and-crafts/perler-bead-sprites.md
+++ b/docs/arts-and-crafts/perler-bead-sprites.md
@@ -32,7 +32,7 @@ You can purchase Perler Beads online or at your local craft store.
 
 * On the keyboard, press Control-C to copy the image (Ctrl+C on Windows or Command+C on Mac).
 * NOTE – you can also open your game in the JavaScript editor and copy the img image code from there.
-* In a new browser tab, open the [MakeCode Arcade Stencilr](https://arcade-stencils.glitch.me) tool.
+* In a new browser tab, open the [MakeCode Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/) tool.
 * Delete the existing image code in the window and paste the image from your game using the keys Control-V on the keyboard (Ctrl+V on Windows or Command+V on Mac).
 
 ![Paste the image](/static/arts-and-crafts/perler-bead-sprites/paste-image.gif)

--- a/docs/arts-and-crafts/tshirt.md
+++ b/docs/arts-and-crafts/tshirt.md
@@ -7,7 +7,7 @@ Do you want to wear your pixel art? The **Arcade Stencilr** tool converts your s
 * open the sprite you want to make T-shirts of
 * select the image area you want to recreate with the **Marquee** tool
 * press Ctrl+C or Command+C to copy the image in the clipboard
-* open [MakeCode Arcade Stencilr](https://arcade-stencils.glitch.me/) (on glitch.me).
+* open [MakeCode Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/) (on GitHub pages).
 * press Ctrl+V or Command+V to paste the image in the image text box
 * download the image under **generate**
 * use the image with your favorite T-Shirt shop!

--- a/docs/hardware/arcade-cabinets/full-size-kiosk.md
+++ b/docs/hardware/arcade-cabinets/full-size-kiosk.md
@@ -100,4 +100,4 @@ _Note: Be sure to secure the top to the bottom with screws (even if temporarily)
 ## Decoration
 
 This is your cabinet, have fun decorating it and personalize it the way you like! We have used
-https://arcade-stencils.glitch.me/ to generate stencils and drawing for cabinets in the past, but feel free to paint freehand in any way that represents your project.
+[Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/) to generate stencils and drawing for cabinets in the past, but feel free to paint freehand in any way that represents your project.

--- a/docs/hardware/raspberry-pi/wooden-cabinet.md
+++ b/docs/hardware/raspberry-pi/wooden-cabinet.md
@@ -103,4 +103,4 @@ To make it easier, we recommend building a jig to position and build this part.
 ## Decoration
 
 This is your cabinet, have fun decorating it and personalize it the way you like! We used the
-https://arcade-stencils.glitch.me/ to generate stencils and drawing on our cabinets.
+[Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/) to generate stencils and drawing on our cabinets.

--- a/docs/test/hardware/full-size-kiosk.md
+++ b/docs/test/hardware/full-size-kiosk.md
@@ -98,4 +98,4 @@ _Note: Be sure to secure the top to the bottom with screws (even if temporarily)
 ## Decoration
 
 This is your cabinet, have fun decorating it and personalize it the way you like! We have used
-https://arcade-stencils.glitch.me/ to generate stencils and drawing for cabinets in the past, but feel free to paint freehand in any way that represents your project.
+[Arcade Stencilr](https://riknoll.github.io/arcade-stenciler/) to generate stencils and drawing for cabinets in the past, but feel free to paint freehand in any way that represents your project.


### PR DESCRIPTION
Update links for the new Stencilr site on GitHub pages: https://riknoll.github.io/arcade-stenciler/

Closes #6957 