### PR TITLE
[stable2.0] bump pxt-core to 11.3.61

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.2.14",
-        "pxt-core": "11.3.59"
+        "pxt-core": "11.3.61"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.16"


### PR DESCRIPTION
bumping core to get the changes for pixelating the skillmap background