### PR TITLE
[stable2.0] bump pxt-core to 11.3.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.2.14",
-        "pxt-core": "11.3.62"
+        "pxt-core": "11.3.63"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.16"


### PR DESCRIPTION
bumping the version for the emergency hotfix