### PR TITLE
update to latest jacdac

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -102,7 +102,7 @@
             },
             "jacdac/pxt-jacdac": {
                 "simx": {
-                    "sha": "1ef117792fecdb6ce91165cc67ff855e540a589a",
+                    "sha": "9a567f397293aa27a06eab91910838f62a100753",
                     "devUrl": "https://jacdac.github.io/jacdac-docs/tools/makecode-sim/"
                 }
             },


### PR DESCRIPTION
@abchatra - any ideas why pxt-arcade build is failing? doesnt seem to be my edit
```
/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/v0.11.14*:refs/remotes/origin/v0.11.14* +refs/tags/v0.11.14*:refs/tags/v0.11.14*
  Error: fatal: could not read Username for 'https://github.com/': terminal prompts disabled
  The process '/usr/bin/git' failed with exit code 128
```