### PR TITLE
use SSH deploy key for cloning pxt-arcade-sim in actions

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -45,11 +45,11 @@ jobs:
           npm install
 
       - name: Checkout pxt-arcade-sim
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           repository: microsoft/pxt-arcade-sim
           ref: v0.11.14
-          token: ${{ secrets.GH_TOKEN }}
+          ssh-key: ${{ secrets.SIM_DEPLOY_KEY }}
           path: node_modules/pxt-arcade-sim
 
       - name: pxt ci (without publish capability)
@@ -84,11 +84,11 @@ jobs:
           npm install
 
       - name: Checkout pxt-arcade-sim
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           repository: microsoft/pxt-arcade-sim
           ref: v0.11.14
-          token: ${{ secrets.GH_TOKEN }}
+          ssh-key: ${{ secrets.SIM_DEPLOY_KEY }}
           path: node_modules/pxt-arcade-sim
 
       - name: pxt ci (with publish capability)

--- a/.github/workflows/pxt-buildvtag.yml
+++ b/.github/workflows/pxt-buildvtag.yml
@@ -33,11 +33,11 @@ jobs:
           npm install
 
       - name: Checkout pxt-arcade-sim
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           repository: microsoft/pxt-arcade-sim
           ref: v0.11.14
-          token: ${{ secrets.GH_TOKEN }}
+          ssh-key: ${{ secrets.SIM_DEPLOY_KEY }}
           path: node_modules/pxt-arcade-sim
 
       - name: pxt ci (with publish capability)


### PR DESCRIPTION
this will require adding a new deploy key secret