### PR TITLE
fix: github release action updated

### DIFF
--- a/libs/template/.github/workflows/makecode-release.yml
+++ b/libs/template/.github/workflows/makecode-release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: install node.js ${{ matrix.node-version }}
+      - name: install node.js 22
         uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
Release actions consistently fail and any changes within your repo to fix it are overwritten when we create a release in the GUI.

This updates the github action to use modern node, no matrix (not needed) and uses modern and supported ways of uploading the assets to the release

Tested and proven here: https://github.com/Emeraldtheporcupine/GelbsBunnyHunt/actions/runs/18633872295
Undone by the release button here: https://github.com/Emeraldtheporcupine/GelbsBunnyHunt/actions/runs/18634404746