### PR TITLE
[Stable2.0] bump pxt-core to 11.3.68 and add npm trusted deployment

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
       - 'main'
-  create:
+
 
 jobs:
   build:
@@ -38,7 +38,6 @@ jobs:
         run: |
           pxt ci
         env:
-          CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}
           PXT_RELEASE_REPO: ${{ secrets.PXT_RELEASE_REPO }}
           NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -1,27 +1,31 @@
 name: pxt-buildpush
 
+permissions:
+  id-token: write  # Required for OIDC
+
 on:
   push:
     # main/master has its own build that includes the crowdin key
     branches-ignore:
       - 'main'
       - 'master'
+  create:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - uses: actions/checkout@main
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@main
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20.x
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: npm install
         run: |
           sudo apt-get install xvfb
@@ -38,9 +42,10 @@ jobs:
         run: |
           pxt ci
         env:
+          CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}
           PXT_RELEASE_REPO: ${{ secrets.PXT_RELEASE_REPO }}
-          NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+          NPM_PUBLISH: true
           CHROME_BIN: chromium-browser
           DISPLAY: :99.0
           CI: true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "12.2.14",
-        "pxt-core": "11.3.66"
+        "pxt-core": "11.3.68"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.11.17"


### PR DESCRIPTION
bumping pxt-core for the hotfix and updating workflows for npm trusted deployment