### PR TITLE
Revert "fix extension paths for bug arena (#7246)"

### DIFF
--- a/docs/skillmap/bug-arena/back-and-forth.md
+++ b/docs/skillmap/bug-arena/back-and-forth.md
@@ -21,13 +21,13 @@ Follow these directions to code your bug's AI algorithm ✨ to move back and for
 
 Our bug moves on its own, but it's important to make sure that it starts out moving in the right direction! 🗺️
 
-From the ``||bug-arena:Bug AI||`` Toolbox category, drag a ``||bug-arena:face towards 0||`` block out and drop into the ``||bug-arena:on start||`` block.
+From the ``||hourOfAi:Bug AI||`` Toolbox category, drag a ``||hourOfAi:face towards 0||`` block out and drop into the ``||hourOfAi:on start||`` block.
 
 ~hint What does this do?
 
 ---
 
-``||bug-arena:Face towards||`` will turn your bug to face a specific angle in degrees where:
+``||hourOfAi:Face towards||`` will turn your bug to face a specific angle in degrees where:
 - 0 = right
 - 90 = down
 - 180 = left
@@ -62,7 +62,7 @@ Do you see your bug move to the right?  Nice! 😊 But what happens when your bu
 
 Nothing 🥺 So let's add some code for when it hits a wall.
 
-From the ``||bug-arena:Bug AI||`` category, drag an ``||bug-arena:on bump wall||`` block out onto the Workspace - you can put it anywhere.
+From the ``||hourOfAi:Bug AI||`` category, drag an ``||hourOfAi:on bump wall||`` block out onto the Workspace - you can put it anywhere.
 
 ```blockconfig.local
 hourOfAi.doAfter(1000, function () {
@@ -78,7 +78,7 @@ hourOfAi.onBumpWall(function () {
 
 ## Turn 90 degrees
 
-From the ``||bug-arena:Bug AI||`` category, drag a ``||bug-arena:turn 90||`` block and drop it into the ``||bug-arena:on bump wall||`` block.
+From the ``||hourOfAi:Bug AI||`` category, drag a ``||hourOfAi:turn 90||`` block and drop it into the ``||hourOfAi:on bump wall||`` block.
 <br/>
 <br/>
 
@@ -111,13 +111,13 @@ We want to turn our bug 90 degrees so it's facing down ⤵️, move a bit ⬇️
 
 To do that, we need to use a block that will wait a certain amount of time ⏱️ before turning again.
 
-From the ``||bug-arena:Bug AI||`` category, drag a ``||bug-arena:run after 1000 ms||`` block out and drop it after the ``||bug-arena:turn 90||`` block.
+From the ``||hourOfAi:Bug AI||`` category, drag a ``||hourOfAi:run after 1000 ms||`` block out and drop it after the ``||hourOfAi:turn 90||`` block.
 
 ~hint What does this do?
 
 ---
 
-The ``||bug-arena:run after||`` block will run the code inside of it after waiting a specified amount of time ⏳.  In this case, we are going to wait 1 second, or 1000 milliseconds (ms), until we turn around again.
+The ``||hourOfAi:run after||`` block will run the code inside of it after waiting a specified amount of time ⏳.  In this case, we are going to wait 1 second, or 1000 milliseconds (ms), until we turn around again.
 
 hint~
 
@@ -139,7 +139,7 @@ hourOfAi.onBumpWall(function () {
 
 ## ↩️ Now turn around
 
-From the ``||bug-arena:Bug AI||`` category, drag another ``||bug-arena:turn 90||`` block out and drop it into the ``||bug-arena:run after||`` block.
+From the ``||hourOfAi:Bug AI||`` category, drag another ``||hourOfAi:turn 90||`` block out and drop it into the ``||hourOfAi:run after||`` block.
 
 ```blockconfig.local
 hourOfAi.doAfter(1000, function () {
@@ -199,7 +199,7 @@ hourOfAi.doAfter(1000, function () {
 
 ## Set the variable value
 
-From the ``||Variables:Variables||`` category, drag a ``||Variables:set angle to 0||`` block into the ``||bug-arena:on start||`` block.
+From the ``||Variables:Variables||`` category, drag a ``||Variables:set angle to 0||`` block into the ``||hourOfAi:on start||`` block.
 
 Type in **-90** as the value for the angle variable, replacing **0**.
 
@@ -219,7 +219,7 @@ hourOfAi.onStart(function () {
 ```
 ## Change the variable value on bump wall
 
-From the ``||Variables:Variables||`` category, drag another ``||Variables:set angle to 0||`` block into the top of the ``||bug-arena:on bump wall||`` block.
+From the ``||Variables:Variables||`` category, drag another ``||Variables:set angle to 0||`` block into the top of the ``||hourOfAi:on bump wall||`` block.
 
 ```blockconfig.local
 hourOfAi.doAfter(1000, function () {
@@ -269,7 +269,7 @@ hourOfAi.onBumpWall(function () {
 
 Now we need to replace our 90 degree turns with our ``||Variables:angle||`` variable.
 
-From the ``||Variables:Variables||`` category, drag two ``||Variables:angle||`` blocks out and drop one into each ``||bug-arena:turn||`` block replacing the **90** degrees.
+From the ``||Variables:Variables||`` category, drag two ``||Variables:angle||`` blocks out and drop one into each ``||hourOfAi:turn||`` block replacing the **90** degrees.
 
 ```blockconfig.local
 hourOfAi.doAfter(1000, function () {
@@ -327,5 +327,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-bug-arena=github:riknoll/bug-arena
+hourOfAi=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/introduction.md
+++ b/docs/skillmap/bug-arena/introduction.md
@@ -96,5 +96,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-bug-arena=github:riknoll/bug-arena
+hourOfAi=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/scribble.md
+++ b/docs/skillmap/bug-arena/scribble.md
@@ -21,7 +21,7 @@ In this tutorial we'll code our bug's AI algorithm ✨ to move in random pattern
 
 Let's have our bug turn a different direction every 5 seconds.  To do this, we'll use a time interval block. 🕓
 
-From the ``||bug-arena:Bug AI||`` toolbox category, drag an ``||bug-arena:every 5000 ms||`` block out onto the Workspace - you can put it anywhere.
+From the ``||hourOfAi:Bug AI||`` toolbox category, drag an ``||hourOfAi:every 5000 ms||`` block out onto the Workspace - you can put it anywhere.
 
 ![Drag and drop blocks](/static/skillmap/bug-arena/dragdrop.gif "animation of dragging and dropping blocks")
 
@@ -29,7 +29,7 @@ From the ``||bug-arena:Bug AI||`` toolbox category, drag an ``||bug-arena:every 
 
 ---
 
-The ``||bug-arena:every 5000 ms||`` block will run the code you put inside of it on a specified millisecond (ms) 🕓 time interval, in this case every 5000 ms or 5 seconds.
+The ``||hourOfAi:every 5000 ms||`` block will run the code you put inside of it on a specified millisecond (ms) 🕓 time interval, in this case every 5000 ms or 5 seconds.
 
 hint~
 
@@ -50,7 +50,7 @@ hourOfAi.every(5000, function () {
 
 ## Turn your bug!
 
-From the ``||bug-arena:Bug AI||`` category, drag a ``||bug-arena:turn 90||`` block out and drop into the ``||bug-arena:every 5000 ms||`` block.
+From the ``||hourOfAi:Bug AI||`` category, drag a ``||hourOfAi:turn 90||`` block out and drop into the ``||hourOfAi:every 5000 ms||`` block.
 <br/>
 <br/>
 
@@ -82,7 +82,7 @@ hourOfAi.every(5000, function () {
 
 Every 5 seconds, we want our bug to turn in a different random direction.
 
-From the ``||Math:Math||`` Toolbox drawer, drag a ``||Math:pick random||`` block and drop in the ``||bug-arena:turn||`` block, replacing the **90**.
+From the ``||Math:Math||`` Toolbox drawer, drag a ``||Math:pick random||`` block and drop in the ``||hourOfAi:turn||`` block, replacing the **90**.
 <br/>
 <br/>
 
@@ -129,9 +129,9 @@ randint(-180, 180)
 
 Let's add some code to make our bug turn ↩️ when it hits a wall.
 
-From the ``||bug-arena:Bug AI||`` category, drag an ``||bug-arena:on bump wall||`` block out onto the Workspace - you can put it anywhere.
+From the ``||hourOfAi:Bug AI||`` category, drag an ``||hourOfAi:on bump wall||`` block out onto the Workspace - you can put it anywhere.
 
-Now drag another ``||bug-arena:turn 90||`` block and drop it into the ``||bug-arena:on bump wall||`` block.
+Now drag another ``||hourOfAi:turn 90||`` block and drop it into the ``||hourOfAi:on bump wall||`` block.
 
 ```blockconfig.local
 hourOfAi.every(5000, function () {
@@ -150,7 +150,7 @@ hourOfAi.onBumpWall(function () {
 
 Again, we want our bug to turn in a random direction, so let's use the 🎲 Pick Random function again.
 
-From the ``||Math:Math||`` Toolbox drawer, drag another ``||Math:pick random||`` block and drop in the ``||bug-arena:turn||`` block, replacing the **90**.
+From the ``||Math:Math||`` Toolbox drawer, drag another ``||Math:pick random||`` block and drop in the ``||hourOfAi:turn||`` block, replacing the **90**.
 
 ```blockconfig.local
 hourOfAi.every(5000, function () {
@@ -199,5 +199,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-bug-arena=github:riknoll/bug-arena
+hourOfAi=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/squares.md
+++ b/docs/skillmap/bug-arena/squares.md
@@ -21,13 +21,13 @@ Let's code your bug to move around the screen coloring the arena in a square pat
 
 Our bug moves on its own, but it's important to make sure that it starts out moving in the right direction! 🗺️
 
-From the ``||bug-arena:Bug AI||`` Toolbox category, drag the ``||bug-arena:face towards 0||`` block out and drop into the ``||bug-arena:on start||`` block.
+From the ``||hourOfAi:Bug AI||`` Toolbox category, drag the ``||hourOfAi:face towards 0||`` block out and drop into the ``||hourOfAi:on start||`` block.
 
 ~hint What does this do?
 
 ---
 
-``||bug-arena:Face towards||`` will turn your bug to face a specific angle in degrees where:
+``||hourOfAi:Face towards||`` will turn your bug to face a specific angle in degrees where:
 - 0 = right
 - 90 = down
 - 180 = left
@@ -66,7 +66,7 @@ Uh-oh!  It gets stuck! 🔄
 
 Let's code in some behavior for when it hits a wall. 🧱
 
-From the ``||bug-arena:Bug AI||`` category, drag an ``||bug-arena:on bump wall||`` block out onto the Workspace - you can put it anywhere.
+From the ``||hourOfAi:Bug AI||`` category, drag an ``||hourOfAi:on bump wall||`` block out onto the Workspace - you can put it anywhere.
 
 ```blockconfig.local
 hourOfAi.every(500, function () {
@@ -84,7 +84,7 @@ hourOfAi.onBumpWall(function () {
 
 ## Turn 90 degrees
 
-From the ``||bug-arena:Bug AI||`` category, drag a ``||bug-arena:turn 90||`` block, and drop it into the ``||bug-arena:on bump wall||`` block.
+From the ``||hourOfAi:Bug AI||`` category, drag a ``||hourOfAi:turn 90||`` block, and drop it into the ``||hourOfAi:on bump wall||`` block.
 <br/>
 <br/>
 
@@ -145,13 +145,13 @@ hourOfAi.every(500, function () {
 
 We need to have our bug check to make sure it's not on a part of the screen that's already covered with its own paint color 🎨 before turning.
 
-From the ``||bug-arena:Bug AI||`` category, drag the ``||bug-arena:every 500 ms||`` group of blocks out onto the Workspace - you can put it anywhere.
+From the ``||hourOfAi:Bug AI||`` category, drag the ``||hourOfAi:every 500 ms||`` group of blocks out onto the Workspace - you can put it anywhere.
 
 ~hint What does this do?
 
 ---
 
-The ``||bug-arena:every 500 ms||`` block will run the code you put inside of it on a specified time interval ⏱️, in this case every 500 milliseconds (ms), or half a second.  The ``||bug-arena:distance to my color||`` block will return the distance in pixels from the front of our bug to its own paint color 🎨. If the distance equals 0, then our bug is standing on it's own paint!
+The ``||hourOfAi:every 500 ms||`` block will run the code you put inside of it on a specified time interval ⏱️, in this case every 500 milliseconds (ms), or half a second.  The ``||hourOfAi:distance to my color||`` block will return the distance in pixels from the front of our bug to its own paint color 🎨. If the distance equals 0, then our bug is standing on it's own paint!
 
 hint~
 
@@ -175,7 +175,7 @@ hourOfAi.every(500, function () {
 
 When the distance from our bug to its own paint color is 0, then we should make a right turn. ↩️
 
-From the ``||bug-arena:Bug AI||`` category, drag a ``||bug-arena:turn 90||`` block out and drop into the ``||Logic:if then||`` block.
+From the ``||hourOfAi:Bug AI||`` category, drag a ``||hourOfAi:turn 90||`` block out and drop into the ``||Logic:if then||`` block.
 
 ```blockconfig.local
 hourOfAi.every(500, function () {
@@ -233,5 +233,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-bug-arena=github:riknoll/bug-arena
+hourOfAi=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/tower.md
+++ b/docs/skillmap/bug-arena/tower.md
@@ -52,5 +52,5 @@ function
 ```
 
 ```package
-bug-arena=github:riknoll/bug-arena
+hourOfAi=github:riknoll/bug-arena
 ```


### PR DESCRIPTION
This reverts commit 8a69fe745993a1715f1c4d879d40e657e7898236.

it worked locally but since it's not working on live let's push this up before cache reset / i'll dig into it more. The highlighting more important than the help links working for now 
