### PR TITLE
just change package statement for bug-arena

### DIFF
--- a/docs/skillmap/bug-arena/back-and-forth.md
+++ b/docs/skillmap/bug-arena/back-and-forth.md
@@ -327,5 +327,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-hourOfAi=github:riknoll/bug-arena
+bug-arena=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/introduction.md
+++ b/docs/skillmap/bug-arena/introduction.md
@@ -96,5 +96,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-hourOfAi=github:riknoll/bug-arena
+bug-arena=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/scribble.md
+++ b/docs/skillmap/bug-arena/scribble.md
@@ -199,5 +199,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-hourOfAi=github:riknoll/bug-arena
+bug-arena=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/squares.md
+++ b/docs/skillmap/bug-arena/squares.md
@@ -233,5 +233,5 @@ hourOfAi.onStart(function () {
 ```
 
 ```package
-hourOfAi=github:riknoll/bug-arena
+bug-arena=github:riknoll/bug-arena
 ```

--- a/docs/skillmap/bug-arena/tower.md
+++ b/docs/skillmap/bug-arena/tower.md
@@ -52,5 +52,5 @@ function
 ```
 
 ```package
-hourOfAi=github:riknoll/bug-arena
+bug-arena=github:riknoll/bug-arena
 ```


### PR DESCRIPTION
Tested all 5 files in both live and beta arcade using tutorial tool now, this change works in both & will have function help links & highlighted items

<img width="1055" height="673" alt="image" src="https://github.com/user-attachments/assets/e2287a73-5f93-4b5f-82ae-54a3e73bb69d" />

because it does work now, i'm leaning heavily towards fixing so we can just do

````
```package
github:riknoll/bug-arena
```
````

and it works rather than having to supply a fake name override, but this covers it for now / tested