### PR TITLE
add browser events to builtinextensionlib

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -202,6 +202,10 @@
             "feather": {
                 "preferred": true,
                 "tags": [ "Hardware", "Controller" ]
+            },
+            "browser-events": {
+                "preferred": true,
+                "tags": [ "Utility", "Controller" ]
             }
         },
         "upgrades": {
@@ -394,14 +398,14 @@
             "url": "https://calliope.cc/en/calliope-mini/accessories/gamekit",
             "variant": "hw---n3"
         },
-        { 
+        {
             "name": "Forward Education CodeCTRL",
             "description": "Code, play, and explore with this handheld micro:bit controller.",
             "imageUrl": "/static/hardware/codectrl.png",
             "url": "https://forwardedu.com/pages/codectrl-for-micro-bit",
             "variant": "hw---n3"
         },
-        { 
+        {
             "name": "micro:bit Arcade Pro",
             "description": "Use the micro:bit with Arcade Pro with a big screen, d-pad and Jacdac support",
             "imageUrl": "/static/hardware/arcade-pro-ef.png",


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6880

looks like the vscode extension pulls the builtin extensions from this list in the targetconfig! adding browser events