### PR TITLE
Update to game.gameOver in froggy tutorial

### DIFF
--- a/docs/tutorials/froggy.md
+++ b/docs/tutorials/froggy.md
@@ -335,7 +335,7 @@ let fly: Sprite = null
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     if (frog.overlapsWith(fly)) {
         //@highlight
-        game.over(true)
+        game.gameOver(true)
     } else {
         //@highlight
         info.changeLifeBy(-1)
@@ -433,7 +433,7 @@ scene.setBackgroundImage(flies_imgs.background)
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () { })
 frog.overlapsWith(fly)
 if (false) { } else { }
-game.over(true)
+game.gameOver(true)
 
 let list = sprites.allOfKind(SpriteKind.Food)
 list.pop().destroy()
@@ -453,7 +453,7 @@ flies_imgs=github:kiki-lee/flies_imgs#v0.0.3
 ```ghost
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
     if (frog.overlapsWith(fly)) {
-        game.over(true)
+        game.gameOver(true)
     } else {
         info.changeLifeBy(-1)
     }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/3675, game.over was deprecated https://github.com/microsoft/pxt-common-packages/blob/0731ff4621f07f9de107ddfb04c683512492644d/libs/game/game.ts#L355 which is why it's showing up differently. There's a decent number of these floating around so needs a pass through rest of repo, this one is to resolve that one specifically though