### PR TITLE
Hopefully fix the v3 share page

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -363,7 +363,8 @@
     <script type="text/javascript" src="/@versionsuff@---embed"></script>
     <!-- <script type="text/javascript" src="/embed.js"></script> -->
     <script>
-            const scriptPageSrc = pxtConfig ? pxtConfig.blobCdnUrl + "scriptPage.js" : "/blb/scriptPage.js";
+            const config = window.pxtConfig || window.pxtWebConfig || (window.pxt && window.pxt.webConfig);
+            const scriptPageSrc = config ? config.blobCdnUrl + "scriptPage.js" : "/blb/scriptPage.js";
             const scriptEl = document.createElement("script");
             scriptEl.type = "text/javascript";
             scriptEl.src = scriptPageSrc;


### PR DESCRIPTION
so apparently docfiles can't use the `/blb/` macro, so we need to manually construct the cdn URL. we need the webconfig to do this, but turns out the share page always loads the index-ref webconfig because it wasn't including the version prefix in the ---embed url. 

this pr fixes that and adds some JS to load the script page js from the webconfig. no real way to test this except to cherry pick it to the v3 branch and try it live!