### PR TITLE
Make Blockly image dropdown menu scrollable

### DIFF
--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -16,3 +16,9 @@
     image-rendering: pixelated;
     -ms-interpolation-mode: nearest-neighbor;
 }
+
+div.blocklyDropDownDiv .blocklyMenu.blocklyImageMenu {
+    max-height: 35vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
## Summary
Blockly image dropdowns (e.g. tile picker) can grow beyond the viewport when they contain many items. This PR limits the menu height and enables scrolling so all items remain reachable.
## Changes
- Add CSS for `div.blocklyDropDownDiv .blocklyMenu.blocklyImageMenu`
  - `max-height: 35vh`
  - `overflow-y: auto`
  - `overflow-x: hidden`
 ## Testing
- Manually verified in the Blocks editor: the image dropdown stays within the viewport and scrolls with large tile sets (desktop + small window).

### Before (master)
<img width="1686" height="975" alt="bug" src="https://github.com/user-attachments/assets/18008d7e-6f03-4f7b-8636-b6d7c8bd4972" />

### After (this PR)
![fix](https://github.com/user-attachments/assets/22fe5d5d-724c-4730-aea5-bcf89b22400a)
