### PR TITLE
[pxt-cli] bump version to v4.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-arcade",
-    "version": "4.0.11",
+    "version": "4.0.12",
     "description": "Small arcade editor for MakeCode",
     "keywords": [
         "JavaScript",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.