### PR TITLE
Add arcade-platformer-blocks to sprite pack extension list

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -100,6 +100,9 @@
             "bladebaillio/image-mapping": {
                 "tags": [ "Visual Effects" ]
             },
+            "rizeupdev/arcade-platformer-blocks": {
+                "tags": [ "Sprite Pack" ]
+            },
             "microsoft/arcade-carnival": {},
             "riknoll/arcade-tile-scanner": {},
             "riknoll/arcade-mini-menu": {},


### PR DESCRIPTION
Add arcade-platformer-blocks to sprite pack extension list in featured extensions.