### PR TITLE
add game jam hall of fame category to home screen

### DIFF
--- a/docs/game-jam-hall-of-fame.md
+++ b/docs/game-jam-hall-of-fame.md
@@ -1,0 +1,261 @@
+# Game Jam Hall of Fame
+Check out the winners for all of our previous game jams!
+
+## Games
+
+### ~ codecard
+* name: Glitch
+* description: Slow time and modify terrain to survive each level! First place winner in Time Jam.
+* author: Web_Headed_Games
+* url: https://arcade.makecode.com/39697-95718-82872-45842
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/39697-95718-82872-45842/thumb
+---
+* name: The Last 30 Seconds of the Universe
+* description: It's (almost) the end of the world and you are the galaxy's only hope... but are you really alone? Second place winner in Time Jam.
+* author: felixtsu
+* url: https://arcade.makecode.com/84204-53947-81636-40195
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/84204-53947-81636-40195/thumb
+---
+* name: True Love Time Machine
+* description: You were the first tester for a brand new time machine--what could go wrong? Well... maybe one thing. Third place winner (tie) in Time Jam.
+* author: Dylan James C. The 1st
+* url: https://arcade.makecode.com/18329-44039-92547-78466
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/18329-44039-92547-78466/thumb
+---
+* name: Flying Through Time
+* description: Use the experimental time wings to swap between past, present, and future as you zip through different landscapes to rescue your friends. Third place winner (tie) in Time Jam
+* author: danger_kitty
+* url: https://arcade.makecode.com/30418-01173-18811-61378
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/30418-01173-18811-61378/thumb
+
+
+
+
+
+---
+* name: The Three Brave Cats
+* description: The legendary Captain Cat sets sail with his friends Sam and Coco to save the world from the evil Robot Cat! First place winner in Ocean Jam
+* author: danger_kitty
+* url: https://arcade.makecode.com/04978-92601-05637-89537
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/04978-92601-05637-89537/thumb
+---
+* name: The Jolly Dodger
+* description: Outfit your ship and sail into enemy territory to plunder some booty and steal all the glory! Dodge enemy fire or you will become someone else's sunken treasure. Second place in Ocean Jam
+* author: Andrew-ski
+* url: https://arcade.makecode.com/04007-23134-26251-74065
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/04007-23134-26251-74065/thumb
+---
+* name: War Subs
+* description: Win battles with enemy ships to gain parts for your own submarine, and try out different combos. Third place winner in Ocean Jam
+* author: Rishi
+* url: https://arcade.makecode.com/05000-25084-90099-51924
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/05000-25084-90099-51924/thumb
+
+
+
+
+---
+* name: Square Rescue
+* description: Awesome opening, evil triangles, and a core mechanic that's easy to understand but has a lot of depth. It's the best kind of difficult that makes your brain bend in interesting ways to learn how to win. First place winner in Traffic Jam
+* author: donnadie
+* url: https://arcade.makecode.com/25787-41781-39930-98285
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/25787-41781-39930-98285/thumb
+---
+* name: HONK!
+* description: Take a moment to enjoy the creative title screen and instructions sequence, then press the A button to HONK! other cars out of your way. Keep an eye out for powerups as you speed up--you'll need them! Second place winner in Traffic Jam
+* author: Unsigned_Arduino's
+* url: https://arcade.makecode.com/97928-66031-26500-83480
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/97928-66031-26500-83480/thumb
+---
+* name: Traffic Panic
+* description: Arrange the randomly generated road segments into a continuous street before the cars arrive! Third place winner in Traffic Jam
+* author: I Am Penguin
+* url: https://arcade.makecode.com/09285-20655-41262-50777
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/09285-20655-41262-50777/thumb
+
+
+
+
+---
+* name: Potato
+* description: Plant vegetables! Summon bees! What more do you need? First place winner in Garden Jam
+* author: reyhanPanci256
+* url: https://arcade.makecode.com/42885-92487-13042-52240
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/42885-92487-13042-52240/thumb
+---
+* name: Garden Crop Duster
+* description: Fly a biplane over fields and bomb them with fertilizer! Don’t stall or crash. Second place winner in Garden Jam
+* author: jacob_c
+* url: https://arcade.makecode.com/95927-10946-55487-19128
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/95927-10946-55487-19128/thumb
+---
+* name: Snail Hike
+* description: Use your puzzle-solving skills to help the snails get to the exit! Third place winner in Garden Jam
+* author: SPerkins25
+* url: https://arcade.makecode.com/17901-55867-81776-14236
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/17901-55867-81776-14236/thumb
+
+
+
+
+---
+* name: Rhythm Code!
+* description: Not just one, but THREE whole rhythm games to test your timing skills! First placve in Cozy Jam
+* author: InvalidProject
+* url: https://arcade.makecode.com/40921-79622-15624-16091
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/40921-79622-15624-16091/thumb
+---
+* name: The Forest Campfire
+* description: A delightful game where you complete quests to help out a goofy cast of characters on a camping trip. Second place winner in Cozy Jam
+* author: Freast & Toast
+* url: https://arcade.makecode.com/50763-65106-55406-25942
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/50763-65106-55406-25942/thumb
+---
+* name: The Joy of Pixels
+* description: A painting sandbox game where you can create and save artworks made out of pixels! Third place winner in Cozy Jam
+* author: Jedi
+* url: https://arcade.makecode.com/08245-57951-20701-25721
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/08245-57951-20701-25721/thumb
+
+
+
+
+---
+* name: Marie Curie
+* description: Play as Marie Curie as she searches for new elements to discover and name! Mix different chemicals to try and create interesting combinations. When you have something that you think might be a new element, press Menu and try submitting it to the Nobel committee! Music by Kiwiphoenix. First place winner in Female Gamechangers Jam
+* author: Peppercorn Studios
+* url: https://arcade.makecode.com/98537-40423-47522-15861
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/98537-40423-47522-15861/thumb
+---
+* name: Lady Lovelace's Time Machine
+* description: Help Ada Lovelace repair your time machine after an accident strands you in the past! Second place winner in Female Gamechangers Jam
+* author: verisutha
+* url: https://arcade.makecode.com/58950-52861-22099-51073
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/58950-52861-22099-51073/thumb
+---
+* name: The Adventures of Frances Perkins
+* description: A terrific platformer where you play as civil rights activist Frances Perkins as she saves children from being forced into child labor. Third place winner (tie) in Female Gamechangers Jam
+* author: Brohann
+* url: https://arcade.makecode.com/24653-68670-93715-48748
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/24653-68670-93715-48748/thumb
+---
+* name: Grace Hopper's Hop-O-Matic
+* description: Take on the role of Grace Hopper's compiler as it processes source code into ones and zeroes. Third place winner (tie) in Female Gamechangers Jam
+* author: rymc88
+* url: https://arcade.makecode.com/14599-75222-61879-27532
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/14599-75222-61879-27532/thumb
+
+
+
+
+---
+* name: Dino Zoo
+* description: A block-based puzzle game where you simulate the circle of life to clear the board of dinosaurs and plants. First place winner in Prehistoric Jam
+* author: SylvanCircle
+* url: https://arcade.makecode.com/22414-21049-08990-36399
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/22414-21049-08990-36399/thumb
+---
+* name: Fossil Clicker
+* description: An addictive paleontology themed idle game. Collect, sell, upgrade, and repeat until you have more money than there are atoms in the universe! Y'know, just like real paleontologists do! Second place winner in Prehistoric Jam
+* author: UnsignedArduino
+* url: https://arcade.makecode.com/39392-36875-05086-87292
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/39392-36875-05086-87292/thumb
+---
+* name: Dino Blast
+* description: An adventure game where you play as a dinosaur exploring the world on a quest to defeat the evil dragon king. NOTE: This game contains rapidly flashing colors and patterns. Third place winner (tie) in Prehistoric Jam
+* author: InvalidProject99
+* url: https://arcade.makecode.com/48432-56072-58827-08148
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/48432-56072-58827-08148/thumb
+---
+* name: Booga Bruh
+* description: Find the parts to your broken time machine and make it back to the present in this story-driven RPG! Third place winner (tie) in Prehistoric Jam
+* author: PixelDoodle
+* url: https://arcade.makecode.com/98099-33981-73376-80879
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/98099-33981-73376-80879/thumb
+
+
+
+
+---
+* name: The MakeCode Forums
+* description: Save the MakeCode forums from the nefarious Scamma in this game about the actual members of the MakeCode online forums! Make sure to check out the sequels too! First place winner in Superheroes in my Community Jam
+* author: ChimbroDaPro
+* url: https://arcade.makecode.com/32696-05327-02222-46404
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/32696-05327-02222-46404/thumb
+---
+* name: Fighting Fire
+* description: A classic shmup where you save a burning building from falling fire balls! Goodness gracious! Second place winner in Superheroes in my Community Jam
+* author: Toolazyfurnames
+* url: https://arcade.makecode.com/30579-25956-44814-00995
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/30579-25956-44814-00995/thumb
+---
+* name: Community Heroes Game Jam
+* description: A tough platformer! Make sure you use keyboard controls for this one! Third place winner in Superheroes in my Community Jam
+* author: Iam
+* url: https://arcade.makecode.com/08008-00125-42136-28163
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/08008-00125-42136-28163/thumb
+
+
+
+
+---
+* name: The Safe Cracker
+* description: A masterclass in making you really stressed out which is exactly what I assume it's like to actually participate in a real heist! First place winner in Heist Jam
+* author: Teddy B.
+* url: https://arcade.makecode.com/50932-20209-20218-60886
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/50932-20209-20218-60886/thumb
+---
+* name: Under Surveillance
+* description: Play as a thief who is committing a series of robberies; each time you return from a heist you can invest your ill-gotten gains to unlock new skills or improve your thief's stats. And boy there are a lot of skills! Second place winner in Heist Jam
+* author: Bilangus
+* url: https://arcade.makecode.com/52784-59082-24354-89134
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/52784-59082-24354-89134/thumb
+---
+* name: Nine Cores
+* description: A twin stick shooter where you collect cores to improve your stats! Third place winner (tie) in Heist Jam
+* author: Nine Cores
+* url: https://arcade.makecode.com/24442-87185-99963-39751
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/24442-87185-99963-39751/thumb
+---
+* name: Katandra: Hollow Heist
+* description: Slash enemies and avoid obstacles in your quest to steal the mysterious "Void Amulet". Third place winner (tie) in Heist Jam
+* author: CopySprite
+* url: https://arcade.makecode.com/99904-43074-40676-04519
+* cardType: sharedExample
+* imageUrl: https://makecode.com/api/99904-43074-40676-04519/thumb
+
+### ~
+
+## See Also
+
+[Game Jam Page](https://arcade.makecode.com/gamejam/heist)

--- a/docs/static/gamejam/jams/time/rules.md
+++ b/docs/static/gamejam/jams/time/rules.md
@@ -7,7 +7,7 @@ We're thrilled to announce the winners of the fifth MakeCode Arcade game jam: Ti
 | -- |
 | &nbsp; |
 
-Polished and imaginative, Web_Headed_Games's [Glitch](https://arcade.makecode.com/04978-92601-05637-89537), is a game where you can slow down time and modify the terrain of the world itself to survive each level. Try speedrunning this game and see if you cant beat your high score while enjoying the beautiful minimalist graphics!
+Polished and imaginative, Web_Headed_Games's [Glitch](https://arcade.makecode.com/39697-95718-82872-45842), is a game where you can slow down time and modify the terrain of the world itself to survive each level. Try speedrunning this game and see if you cant beat your high score while enjoying the beautiful minimalist graphics!
 
 ## Second Place: The Last 30 Seconds of the Universe
 | [![The Last 30 Seconds of the Universe screenshot](/static/gamejam/jams/time/assets/loopfighter.png)](https://arcade.makecode.com/84204-53947-81636-40195) |

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -404,6 +404,7 @@
         "Game Jam": "game-jam",
         "Advanced Livestream": "advanced-stream",
         "Community Games": "community",
+        "Game Jam Hall of Fame": "game-jam-hall-of-fame",
         "Game Design Concepts": "concepts",
         "Graphics and Math": "graphics-math",
         "Arts and Crafts": "arts-and-crafts",


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7555

adds a hall of fame category to the home screen with all the previous first, second, and third place winners!

also fixed a link in one of the game jam pages which i noticed was pointing to the wrong game (oops)

<img width="1181" height="230" alt="image" src="https://github.com/user-attachments/assets/79a1e87e-b1ad-4869-93c0-a9be621a51e1" />
