### PR TITLE
update github actions workflow to use deploy key

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -109,8 +109,37 @@ jobs:
         env:
           CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}
-          PXT_RELEASE_REPO: ${{ secrets.PXT_RELEASE_REPO }}
           NPM_PUBLISH: true
           CHROME_BIN: chromium-browser
           DISPLAY: :99.0
           CI: true
+          PXT_SKIP_GIT_COMMIT: true
+
+      - name: Clone release repo
+        uses: actions/checkout@main
+        with:
+          repository: ${{ secrets.BUILT_REPO_NAME }}
+          path: tmp/releases/release
+          fetch-depth: 3
+          fetch-tags: true
+          ssh-key: ${{ secrets.BUILT_REPO_DEPLOY_KEY }}
+
+      - name: Read release info
+        id: release_info
+        run: |
+          tag=$(cat tmp/releases/release.json | jq -r '.tag')
+          url=$(cat tmp/releases/release.json | jq -r '.url')
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Push artifacts to release repo
+        run: |
+          cp -a tmp/releases/built/. tmp/releases/release
+          cd tmp/releases/release
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git add .
+          git commit -m "Release ${{steps.release_info.outputs.tag}} from ${{steps.release_info.outputs.url}}"
+          git tag ${{steps.release_info.outputs.tag}}
+          git push
+          git push --tags

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: 20.x
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: npm install
         run: |
@@ -87,7 +87,7 @@ jobs:
           node-version: 20.x
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: npm install
         run: |

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.1.11",
-        "pxt-core": "12.3.10"
+        "pxt-core": "13.1.5"
     },
     "optionalDependencies": {
         "pxt-arcade-sim": "microsoft/pxt-arcade-sim.git#v0.12.3"


### PR DESCRIPTION
updating the github action workflow to use deploy keys instead of PATs