### PR TITLE
hide built in extensions from ext search

### DIFF
--- a/libs/base/pxt.json
+++ b/libs/base/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/base"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/base",
+    "hidden": true
 }

--- a/libs/game---light/pxt.json
+++ b/libs/game---light/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/game---light"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/game---light",
+    "hidden": true
 }

--- a/libs/game/pxt.json
+++ b/libs/game/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/game"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/game",
+    "hidden": true
 }

--- a/libs/hw---n3/pxt.json
+++ b/libs/hw---n3/pxt.json
@@ -38,6 +38,7 @@
             "MICROBIT_CODAL": 0
         }
     },
+            "hidden": true,
     "dalDTS": {
         "corePackage": "../core---nrf52"
     }

--- a/libs/hw---n3/pxt.json
+++ b/libs/hw---n3/pxt.json
@@ -38,7 +38,7 @@
             "MICROBIT_CODAL": 0
         }
     },
-            "hidden": true,
+    "hidden": true,
     "dalDTS": {
         "corePackage": "../core---nrf52"
     }

--- a/libs/hw---n4/pxt.json
+++ b/libs/hw---n4/pxt.json
@@ -36,7 +36,7 @@
             "DEVICE_WEBUSB": 0
         }
     },
-            "hidden": true,
+    "hidden": true,
     "dalDTS": {
         "corePackage": "../core---nrf52"
     }

--- a/libs/hw---n4/pxt.json
+++ b/libs/hw---n4/pxt.json
@@ -36,6 +36,7 @@
             "DEVICE_WEBUSB": 0
         }
     },
+            "hidden": true,
     "dalDTS": {
         "corePackage": "../core---nrf52"
     }

--- a/libs/hw---rp2040/pxt.json
+++ b/libs/hw---rp2040/pxt.json
@@ -35,6 +35,7 @@
             "DEVICE_WEBUSB": 1
         }
     },
+            "hidden": true,
     "dalDTS": {
         "corePackage": "../core---rp2040"
     }

--- a/libs/hw---rp2040/pxt.json
+++ b/libs/hw---rp2040/pxt.json
@@ -35,7 +35,7 @@
             "DEVICE_WEBUSB": 1
         }
     },
-            "hidden": true,
+    "hidden": true,
     "dalDTS": {
         "corePackage": "../core---rp2040"
     }

--- a/libs/hw---rpi/pxt.json
+++ b/libs/hw---rpi/pxt.json
@@ -1,5 +1,6 @@
 {
     "name": "hw---rpi",
+    "hidden": true,
     "description": "Raspberry Pi",
     "files": [
         "keys.cpp",

--- a/libs/hw---samd51/pxt.json
+++ b/libs/hw---samd51/pxt.json
@@ -33,6 +33,7 @@
             "DEVICE_WEBUSB": 1
         }
     },
+            "hidden": true,
     "additionalFilePath": "../hw",
     "public": true,
     "skipLocalization": true,

--- a/libs/hw---samd51/pxt.json
+++ b/libs/hw---samd51/pxt.json
@@ -33,7 +33,7 @@
             "DEVICE_WEBUSB": 1
         }
     },
-            "hidden": true,
+    "hidden": true,
     "additionalFilePath": "../hw",
     "public": true,
     "skipLocalization": true,

--- a/libs/hw---stm32f401/pxt.json
+++ b/libs/hw---stm32f401/pxt.json
@@ -37,6 +37,7 @@
             "PXT_DEFAULT_ACCELEROMETER": "ACCELEROMETER_TYPE_MMA8453"
         }
     },
+            "hidden": true,
     "dalDTS": {
         "corePackage": "../core---stm32"
     }

--- a/libs/hw---stm32f401/pxt.json
+++ b/libs/hw---stm32f401/pxt.json
@@ -37,7 +37,7 @@
             "PXT_DEFAULT_ACCELEROMETER": "ACCELEROMETER_TYPE_MMA8453"
         }
     },
-            "hidden": true,
+     "hidden": true,
     "dalDTS": {
         "corePackage": "../core---stm32"
     }

--- a/libs/hw---vm/pxt.json
+++ b/libs/hw---vm/pxt.json
@@ -1,5 +1,6 @@
 {
     "name": "hw---vm",
+    "hidden": true,
     "description": "VM",
     "files": [
         "sdlmain.cpp",

--- a/libs/hw/pxt.json
+++ b/libs/hw/pxt.json
@@ -12,5 +12,6 @@
         "game": "file:../game"
     },
     "public": true,
-    "skipLocalization": true
+    "skipLocalization": true,
+    "hidden": true
 }

--- a/libs/mixer---ext/pxt.json
+++ b/libs/mixer---ext/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---ext"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---ext",
+    "hidden": true
 }

--- a/libs/mixer---linux/pxt.json
+++ b/libs/mixer---linux/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---linux"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---linux",
+    "hidden": true
 }

--- a/libs/mixer---none/pxt.json
+++ b/libs/mixer---none/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---none"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---none",
+    "hidden": true
 }

--- a/libs/mixer---nrf52/pxt.json
+++ b/libs/mixer---nrf52/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---nrf52"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---nrf52",
+    "hidden": true
 }

--- a/libs/mixer---rp2040/pxt.json
+++ b/libs/mixer---rp2040/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---rp2040"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---rp2040",
+    "hidden": true
 }

--- a/libs/mixer---samd/pxt.json
+++ b/libs/mixer---samd/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---samd"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---samd",
+    "hidden": true
 }

--- a/libs/mixer---stm32/pxt.json
+++ b/libs/mixer---stm32/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---stm32"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer---stm32",
+    "hidden": true
 }

--- a/libs/mixer/pxt.json
+++ b/libs/mixer/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/mixer",
+    "hidden": true
 }

--- a/libs/power/pxt.json
+++ b/libs/power/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/power"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/power",
+    "hidden": true
 }

--- a/libs/screen---ext/pxt.json
+++ b/libs/screen---ext/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen---ext"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen---ext",
+    "hidden": true
 }

--- a/libs/screen---linux/pxt.json
+++ b/libs/screen---linux/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen---linux"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen---linux",
+    "hidden": true
 }

--- a/libs/screen---st7735/pxt.json
+++ b/libs/screen---st7735/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen---st7735"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen---st7735",
+    "hidden": true
 }

--- a/libs/screen/pxt.json
+++ b/libs/screen/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/screen",
+    "hidden": true
 }

--- a/libs/settings---files/pxt.json
+++ b/libs/settings---files/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/settings---files"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/settings---files",
+    "hidden": true
 }

--- a/libs/settings/pxt.json
+++ b/libs/settings/pxt.json
@@ -1,3 +1,4 @@
 {
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/settings"
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/settings",
+    "hidden": true
 }


### PR DESCRIPTION
these were getting exposed due to change to show extensions that have been added to project still in extension search, so just hiding them. there aren't any in this set that seemed like a bluetooth / radio situation where you'd want to have them available to search and swap, so 'hidden' instead of 'searchOnly'