### PR TITLE
skip sim clone step in workflow on external prs

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -97,11 +97,14 @@ jobs:
 
       - name: Checkout pxt-arcade-sim
         uses: actions/checkout@v5
+        if: env.SIM_DEPLOY_KEY
         with:
           repository: microsoft/pxt-arcade-sim
           ref: v0.12.3
           ssh-key: ${{ secrets.SIM_DEPLOY_KEY }}
           path: node_modules/pxt-arcade-sim
+        env:
+          SIM_DEPLOY_KEY: ${{ secrets.SIM_DEPLOY_KEY }}
 
       - name: pxt ci (with publish capability)
         run: |


### PR DESCRIPTION
our workflow fails on external prs because it cannot clone the pxt-arcade-sim repo. this PR adds a check to see if the secret is defined before executing that step. the clone isn't actually necessary for external PRs, the repo build will just skip building the sim.