### PR TITLE
Register Game Designer's Kit (hw---gdk) in the hardware picker

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -402,6 +402,13 @@
             "variant": "hw---n3"
         },
         {
+            "name": "Game Designer's Kit",
+            "description": "micro:bit V2 shield with 1.8\" ST7735 color display and GPIO arcade buttons",
+            "imageUrl": "/static/hardware/game-designers-kit.jpg",
+            "url": "https://github.com/Deltabotixpvt/Game-Designer-s-Kit",
+            "variant": "hw---gdk"
+        },
+        {
             "name": "Adafruit M4",
             "description": "Learn how to run your games on micro-controllers from Adafruit",
             "imageUrl": "/static/hardware/adafruitm4.jpg",


### PR DESCRIPTION
## Summary

Follow-up to #7600. `hw---gdk` (Game Designer's Kit) was merged, but the board does **not** appear in the **Choose your Hardware** picker on `master`/beta. This PR re-adds its `hardwareOptions` entry in `targetconfig.json` so it becomes selectable.

## Root cause

The hardware picker is populated **only** from `targetconfig.json` → `hardwareOptions`. A bundled package's `pxt.json` `card` (`cardType: "hw"`) is **not** sufficient on its own — for example, `hw---n4` and `hw---rpi` both have `cardType: "hw"` cards but are intentionally absent from `hardwareOptions` and therefore do not appear in the picker.

During #7600 the `hw---gdk` `hardwareOptions` entry was removed under the mistaken assumption it was a duplicate of the package card. As a result the board is bundled and compilable but never shown in the picker.

## Change

Re-add the single `hw---gdk` entry to `hardwareOptions`, matching the pattern used by every other selectable board (`hw---n3`, `hw---samd51`, `hw---stm32f401`, `hw---rp2040`):

```json
{
    "name": "Game Designer's Kit",
    "description": "micro:bit V2 shield with 1.8\" ST7735 color display and GPIO arcade buttons",
    "imageUrl": "/static/hardware/game-designers-kit.jpg",
    "url": "https://github.com/Deltabotixpvt/Game-Designer-s-Kit",
    "variant": "hw---gdk"
}
```

## Notes

- No board source, pin maps, or drivers are changed — this is registration only.
- The image (`/static/hardware/game-designers-kit.jpg`) and the `hw---gdk` package were already merged in #7600.
- Does not reintroduce a duplicate: as shown by `hw---n4`/`hw---rpi`, the package `hw` card does not itself add a picker entry.

## Test plan

- [x] `targetconfig.json` parses as valid JSON
- [x] `git diff --check` clean
- [ ] Verify **Game Designer's Kit** appears in **Choose your Hardware** on beta after this merges
