### PR TITLE
Add imageUrl for sports game jam "see more"

### DIFF
--- a/docs/game-jam.md
+++ b/docs/game-jam.md
@@ -102,6 +102,7 @@ Check out the winners of the 12th Official Microsoft MakeCode Game Jam, featurin
 * url: https://arcade.makecode.com/gamejam/sports
 * imageUrl: /static/gamejam/jams/sports/assets/sports-jam-logo.png
 
+
 ### ~
 
 ## See Also

--- a/docs/game-jam.md
+++ b/docs/game-jam.md
@@ -100,6 +100,7 @@ Check out the winners of the 12th Official Microsoft MakeCode Game Jam, featurin
 * cardType: link
 * directOpen: true
 * url: https://arcade.makecode.com/gamejam/sports
+* imageUrl: /static/gamejam/jams/sports/assets/sports-jam-logo.png
 
 ### ~
 


### PR DESCRIPTION
in beta, when you search 'see more', this code card pops up, and was reported as a bit confusing. 
<img width="1035" height="427" alt="image" src="https://github.com/user-attachments/assets/5daa81e8-8a8d-44da-9ae3-432d0317f8d1" />

Do think it's a useful card to have though, especially if you just want to search e.g. game jam to have it pop up. How do we feel about just adding in the image for the jam it refers to instead of leaving as a blank button? 
<img width="1277" height="324" alt="image" src="https://github.com/user-attachments/assets/a694c11a-f63b-47d1-84bd-89ce36f21370" />

Do have option to remove it now https://github.com/microsoft/pxt/pull/11501 but this feels like a solid enough result to me / good chance what the user might actually want
<img width="1287" height="647" alt="image" src="https://github.com/user-attachments/assets/e814dd5d-ed72-4f08-ba7f-de367890e508" />
