### PR TITLE
reverting gdk markdown changes temporarily

### DIFF
--- a/docs/arcade-devices.md
+++ b/docs/arcade-devices.md
@@ -125,14 +125,14 @@ These boards run MakeCode Arcade games. Choose a board to find out more about it
         "url": "https://calliope.cc/en/calliope-mini/accessories/gamekit",
         "variant": "hw---n3"
     },
-    { 
+    {
         "name": "Forward Education CodeCTRL",
         "description": "Code, play, and explore with this handheld micro:bit controller.",
         "imageUrl": "/static/hardware/codectrl.png",
         "url": "https://forwardedu.com/pages/codectrl-for-micro-bit",
         "variant": "hw---n3"
     },
-    { 
+    {
         "name": "micro:bit Arcade Pro",
         "description": "Use the micro:bit with Arcade Pro with a big screen, d-pad and Jacdac support",
         "imageUrl": "/static/hardware/arcade-pro-ef.png",
@@ -145,13 +145,6 @@ These boards run MakeCode Arcade games. Choose a board to find out more about it
         "imageUrl": "/static/hardware/tomatocube-display-shield.png",
         "url": "https://tomatocube.com/product/makecode-arcade-display-shield-for-microbit",
         "variant": "hw---n3"
-    },
-    {
-        "name": "Game Designer's Kit",
-        "description": "micro:bit V2 shield with 1.8\" ST7735 color display and GPIO arcade buttons",
-        "imageUrl": "/static/hardware/game-designers-kit.jpg",
-        "url": "https://github.com/Deltabotixpvt/Game-Designer-s-Kit",
-        "variant": "hw---gdk"
     },
     {
         "name": "Adafruit M4",

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -134,24 +134,18 @@ Shields are based on our guidelines, adhere to open source hardware reference de
         "url": "http://www.kitronik.co.uk/56116"
     },
     {
-        "name": "Game Designer's Kit",
-        "description": "micro:bit V2 shield with 1.8\" ST7735 color display and GPIO arcade buttons",
-        "imageUrl": "/static/hardware/game-designers-kit.jpg",
-        "url": "https://github.com/Deltabotixpvt/Game-Designer-s-Kit"
-    },
-    {
         "name": "Calliope GameKit Shield",
         "description": "Use the Calliope mini with GameKit to bring your game ideas to life",
         "imageUrl": "/static/hardware/gamekit.png",
         "url": "https://calliope.cc/en/calliope-mini/accessories/gamekit"
     },
-    { 
+    {
         "name": "Forward Education CodeCTRL",
         "description": "Code, play, and explore with this handheld micro:bit controller.",
         "imageUrl": "/static/hardware/codectrl.png",
         "url": "https://forwardedu.com/pages/codectrl-for-micro-bit"
     },
-    { 
+    {
         "name": "micro:bit Arcade Pro",
         "description": "Use the micro:bit with Arcade Pro with a big screen, d-pad and Jacdac support",
         "imageUrl": "/static/hardware/arcade-pro-ef.png",


### PR DESCRIPTION
temporarily removing the GDK entries in our hardware markdown while the changes are still in beta.

once beta is released to live, we can revert this revert.