### PR TITLE
Reformat 'bulleted' list under the 'test' task in Music tutorial

### DIFF
--- a/docs/tutorials/music.md
+++ b/docs/tutorials/music.md
@@ -553,13 +553,10 @@ controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
 
 ## {Step 17}
 
-- :binoculars: Test your final music player.
-
-
-- The arrows should load a song
-- The (A) button should play the loaded song
-- The (B) button should stop all songs
-
+- :binoculars: Test your final music player.<br/>
+**•** The arrows should load a song<br/>
+**•** The (A) button should play the loaded song</br>
+**•** The (B) button should stop all songs
 
 
 ```blockconfig.local


### PR DESCRIPTION
The custom rendering is confused with the bulleted list under the "Test" task in the Music tutorial. I think it's expecting a Font Awesome symbol identifier to follow the markdown 'list' (`-`) character.

```
- :binoculars: Test your final music player.


- The arrows should load a song
- The (A) button should play the loaded song
- The (B) button should stop all songs
```

So, a fix is to replace with some literal chars to avoid the confusion.

```
- :binoculars: Test your final music player.<br/>
**•** The arrows should load a song<br/>
**•** The (A) button should play the loaded song</br>
**•** The (B) button should stop all songs
```

Closes #7630