### PR TITLE
Set USE_RGB444 for the samd51 hardware variant

### DIFF
--- a/libs/hw---samd51/pxt.json
+++ b/libs/hw---samd51/pxt.json
@@ -30,7 +30,8 @@
         },
         "config": {
             "DEVICE_USB": 1,
-            "DEVICE_WEBUSB": 1
+            "DEVICE_WEBUSB": 1,
+            "USE_RGB444": 1
         }
     },
     "hidden": true,


### PR DESCRIPTION
Follow-up to the pxt side of [pxt-common-packages#1627](https://github.com/microsoft/pxt-common-packages/pull/1627).

That PR fixes greyscale rendering on newer PyBadge / PyBadge LC panels, and it is already live in common-packages 14.1.3 which this repo pinned in [181ee59](https://github.com/microsoft/pxt-arcade/commit/181ee59). But the new path is gated on `#ifdef USE_RGB444` and nothing defines that symbol, so it compiles out and arcade.makecode.com builds still take the RGBSET path. A user confirmed that today: [comment](https://github.com/microsoft/pxt-common-packages/pull/1627#issuecomment-5366637806).

This defines the flag for `hw---samd51`. `screen.cpp` already guards the path at runtime on `CFG_BOOTLOADER_BOARD_ID`, so the Kitronik boards that share this variant fall back to RGBSET.

@riknoll this is the flag you offered to wire up, let me know if it belongs somewhere else in the build.

Fixes microsoft/pxt-arcade#6861

🤖 Generated with [Claude Code](https://claude.com/claude-code)