### PR TITLE
take share page theme from default theme and add hidelogos flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -38,6 +38,17 @@
             }
         }
 
+        .pxt-theme-root {
+            --pxt-header-background: #116E79;
+            --pxt-header-foreground: #ffffff;
+            --pxt-neutral-background1: #ffffff;
+            --pxt-neutral-foreground1: #000000;
+        }
+
+        body.pxt-theme-root a.common-button:hover {
+            color: var(--pxt-primary-foreground);
+        }
+
         .ui.item.logo img {
             object-fit: contain;
         }
@@ -67,11 +78,6 @@
             margin: 0 1rem;
         }
         header {
-            --pxt-header-background: #f76820;
-            --pxt-header-foreground: #ffffff;
-            --pxt-neutral-background1: #ffffff;
-            --pxt-neutral-foreground1: #000000;
-
             margin-bottom: 1rem;
         }
 
@@ -154,7 +160,7 @@
     </style>
 </head>
 
-<body id='root' class='root expandIt share-page'>
+<body id='root' class='root expandIt share-page pxt-theme-root'>
     <header>
         <div class="common-menubar header" role="menubar" aria-label="Header">
             <div class="header-left">

--- a/docs/static/script-page.css
+++ b/docs/static/script-page.css
@@ -6,7 +6,7 @@ body#root {
 
 body#root.share-page {
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    background-color: #fdf3e0;
+    background-color: var(--pxt-target-background3);
 }
 
 body#root.share-page #pagemenu .ui.header {

--- a/scriptPage/index.ts
+++ b/scriptPage/index.ts
@@ -16,7 +16,7 @@ declare namespace pxt.runner {
 }
 
 (window as any).initScriptPage = function init(info: PubInfo) {
-    const editorEmbedURL = `/${info.versionSuffix}#sandbox:${info.projectId}`;
+    const editorEmbedURL = `/${info.versionSuffix}?hidelogos=1#sandbox:${info.projectId}`;
     const showCodeButton = document.getElementById("show-code-button");
     const showCodeButtonIcon = showCodeButton.getElementsByTagName("i").item(0);
     const showCodeButtonOverflow = document.getElementById("show-code-button-overflow");
@@ -118,6 +118,8 @@ declare namespace pxt.runner {
         iframe.src = src;
         return iframe;
     }
+
+    ThemeManager.getInstance().switchColorTheme(pxt.appTarget?.appTheme?.defaultColorTheme || "light");
 }
 
 function fireClickOnEnter(e: KeyboardEvent) {

--- a/scriptPage/themeManager.ts
+++ b/scriptPage/themeManager.ts
@@ -1,0 +1,141 @@
+/// <reference path='../node_modules/pxt-core/localtypings/dompurify.d.ts' />
+
+/**
+ * This file is copied directly from pxt/react-common/components/theming/themeManager.ts
+ * The only modification is the reference path above
+ */
+
+interface ThemeChangeSubscriber {
+    subscriberId: string;
+    onColorThemeChange: () => void;
+}
+
+/*
+ * Class to handle theming operations, like loading and switching themes.
+ * Each instance can manage themes for a specific document.
+*/
+class ThemeManager {
+    private static instances: Map<Document, ThemeManager> = new Map();
+    private currentTheme: pxt.ColorThemeInfo;
+    private subscribers: ThemeChangeSubscriber[];
+    private document: Document;
+
+    private constructor(doc: Document) {
+        this.document = doc;
+    }
+
+    public static getInstance(doc: Document = document): ThemeManager {
+        if (!ThemeManager.instances.has(doc)) {
+            ThemeManager.instances.set(doc, new ThemeManager(doc));
+        }
+        return ThemeManager.instances.get(doc);
+    }
+
+    public static isCurrentThemeHighContrast(doc: Document = document): boolean {
+        const themeManager = ThemeManager.getInstance(doc);
+        return themeManager.isHighContrast(themeManager.getCurrentColorTheme()?.id);
+    }
+
+    public getCurrentColorTheme(): Readonly<pxt.ColorThemeInfo> {
+        return this.currentTheme;
+    }
+
+    public isKnownTheme(themeId: string): boolean {
+        return !!pxt.appTarget?.colorThemeMap?.[themeId];
+    }
+
+    public getAllColorThemes(): pxt.ColorThemeInfo[] {
+        const allThemes = pxt.appTarget?.colorThemeMap ? Object.values(pxt.appTarget.colorThemeMap) : [];
+        return allThemes.sort((a, b) => {
+            // Lower weight at the front.
+            if (a.weight !== b.weight) {
+                return (a.weight ?? Infinity) - (b.weight ?? Infinity);
+            }
+            else {
+                return a.id.localeCompare(b.id);
+            }
+        });
+    }
+
+    public isHighContrast(themeId: string) {
+        return themeId && themeId === pxt.appTarget?.appTheme?.highContrastColorTheme;
+    }
+
+    // This is a workaround to ensure we still get all the special-case high-contrast styling
+    // until we fully support high contrast via color themes (requires a lot of overrides).
+    // TODO : this should be removed once we do fully support it.
+    private performHighContrastWorkaround(themeId: string) {
+        if (this.isHighContrast(themeId)) {
+            this.document.body.classList.add("high-contrast");
+            this.document.body.classList.add("hc");
+        } else {
+            this.document.body.classList.remove("high-contrast");
+            this.document.body.classList.remove("hc");
+        }
+    }
+
+    public switchColorTheme(themeId: string) {
+        if (themeId === this.getCurrentColorTheme()?.id) {
+            return;
+        }
+
+        const theme = pxt.appTarget?.colorThemeMap?.[themeId];
+
+        // Programmatically set the CSS variables for the theme
+        if (theme) {
+            const themeAsStyle = getFullColorThemeCss(theme);
+            const styleElementId = "theme-override";
+            let styleElement = this.document.getElementById(styleElementId);
+            if (!styleElement) {
+                styleElement = this.document.createElement("style");
+                styleElement.id = styleElementId;
+                this.document.head.appendChild(styleElement);
+            }
+
+            // textContent is safer than innerHTML, less vulnerable to XSS
+            styleElement.textContent = `.pxt-theme-root { ${themeAsStyle} }`;
+
+            this.performHighContrastWorkaround(themeId);
+
+            this.currentTheme = theme;
+            this.notifySubscribers();
+        }
+    }
+
+    public subscribe(subscriberId: string, onColorThemeChange: () => void) {
+        if (this.subscribers?.some(s => s.subscriberId === subscriberId)) {
+            return;
+        }
+
+        if (!this.subscribers) {
+            this.subscribers = [];
+        }
+
+        this.subscribers.push({ subscriberId, onColorThemeChange });
+    }
+
+    public unsubscribe(subscriberId: string) {
+        this.subscribers = this.subscribers.filter(s => s.subscriberId !== subscriberId);
+    }
+
+    private notifySubscribers() {
+        this.subscribers?.forEach(s => s.onColorThemeChange());
+    }
+}
+
+function getFullColorThemeCss(theme: pxt.ColorThemeInfo) {
+    let css = "";
+
+    for (const [key, value] of Object.entries(theme.colors)) {
+        css += `--${key}: ${value};\n`;
+    }
+
+    if (theme.overrideCss) {
+        css += `${theme.overrideCss}\n`;
+    }
+
+    // Sanitize the CSS
+    css = DOMPurify.sanitize(css);
+
+    return css;
+}

--- a/scriptPage/tsconfig.json
+++ b/scriptPage/tsconfig.json
@@ -8,6 +8,8 @@
         "rootDir": ".",
         "newLine": "LF",
         "types": [],
-        "sourceMap": false
+        "sourceMap": false,
+        "strictPropertyInitialization": false,
+        "strictNullChecks": false
     }
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7633
fixes https://github.com/microsoft/pxt-arcade/issues/7525

<img width="1169" height="637" alt="image" src="https://github.com/user-attachments/assets/7fa0be16-ed2f-4659-a154-f27cfacbe660" />

this pr ports over the thememanager from pxt and uses it to set the theme css in the page. unfortunately, we can't take the user's preference unless we add auth to this page so right now it just always grabs the default

also adds the hidelogos flag i just added to pxt

and finally, i checked in the vscode preference file that says to use the local typescript version.