### PR TITLE
Fix README spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ a package of images.
    left to right. For a sample file see [here](https://github.com/microsoft/pxt-arcade/blob/master/libs/device/smallFood/small.json)
 1. From the root of your package, run the command `pxt buildsprites SUBDIR`
    where `SUBDIR` is the name of the directory containing the assets.
-1. Two files will be generated in the package root, one with the extenstion `.ts`
+1. Two files will be generated in the package root, one with the extension `.ts`
    and one with the extension `.jres`. Add both to the package's `pxt.json`
 1. You're done! The images will show up in the Image category when the package
    is added to a project
@@ -172,7 +172,7 @@ Install gulp:
 npm install -g gulp
 ```
 
-and in a seperate terminal from `pxt serve` and in the pxt/ folder, run:
+and in a separate terminal from `pxt serve` and in the pxt/ folder, run:
 
 ```
 gulp watch


### PR DESCRIPTION
## Summary

Fix two spelling errors in the main README:

- `extenstion` → `extension` in the sprite package instructions
- `seperate` → `separate` in the local development instructions

No commands or documented behavior are changed.

## Verification

- `codespell README.md`
- `git diff --check`

## AI assistance

AI assistance was used to locate the typos and prepare this documentation-only change. The final diff was manually reviewed and verified with `codespell` before submission.
