### PR TITLE
make hc theme default to hc mode

### DIFF
--- a/theme/color-themes/pxt-high-contrast.json
+++ b/theme/color-themes/pxt-high-contrast.json
@@ -1,0 +1,8 @@
+{
+    "id": "pxt-high-contrast",
+    "name": "High Contrast",
+    "weight": 100,
+    "defaultSimulatorTheme": "high-contrast",
+    "monacoBaseTheme": "hc-black",
+    "colors": {}
+}


### PR DESCRIPTION
minor tweak, didn't think to make it so high contrast theme defaults to high contrast simulator (because i had set hc simulator explicitly before testing switching to theme / etc) https://arcade.makecode.com/app/3c07dc108a9f83808cb38b1bc3f724f0b16cb509-737178815c#editor