### PR TITLE
hide adafruit samd51 hardware card

### DIFF
--- a/libs/hw---samd51adafruit/pxt.json
+++ b/libs/hw---samd51adafruit/pxt.json
@@ -32,5 +32,6 @@
     "skipLocalization": true,
     "dalDTS": {
         "corePackage": "../core---samd"
-    }
+    },
+    "experimentalHw": true
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/7703

this flag hides the card from the hardware selection dialog unless the experimental hardware experiment is enabled.